### PR TITLE
http query arguments evaluated as strings or variables

### DIFF
--- a/lib/plankton/https.rb
+++ b/lib/plankton/https.rb
@@ -36,7 +36,7 @@ module Plankton
           while @tok.current != 'end' && @tok.current != 'EOF'
             q = @tok.eat_a_variable.to_sym
             @tok.eat_a ':'
-            info[:query][q] = string_expr
+            info[:query][q] = expr
           end
 
           @tok.eat_a 'end'

--- a/lib/plankton/instructions/http_instruction.rb
+++ b/lib/plankton/instructions/http_instruction.rb
@@ -16,18 +16,21 @@ module Plankton
 
       info = {}
 
-      @info_expr.each do |k,v| 
+      @info_expr.each do |k,v|
 
         if k != :query
           info[k] = scope.substitute v
-        else 
+        else
           info[:query] = {}
           v.each do |q,w|
-            info[:query][q] = scope.substitute w 
+            evaled = scope.evaluate w
+            info[:query][q] = scope.substitute evaled
           end
         end
       end
 
+      puts "http-scope info_expr:"
+      puts @info_expr
       uri = URI(info[:host] + ':' + info[:port] + info[:path])
       uri.query = URI.encode_www_form(info[:query])
       res = Net::HTTP.get_response(uri)
@@ -49,7 +52,7 @@ module Plankton
 
     end
 
-    def to_html 
+    def to_html
       info_expr.to_s
     end
 


### PR DESCRIPTION
Currently, http query arguments have to be strings, which is no good for parameterizing protocols (e.g. automatically inputting an item id for the qrcode). Using expr instead of string_expr to get the query value and then running scope.evaluate on the result produces the right string for both a variable input or a string input.
