### PR TITLE
add method in api find to return url for upload

### DIFF
--- a/app/api/api_find.rb
+++ b/app/api/api_find.rb
@@ -30,12 +30,10 @@ module ApiFind
                "task" => Task, "sample_type" => SampleType, "object_type" => ObjectType,
                "task_prototype" => TaskPrototype, "touch" => Touch,
                "workflow_thread"=>WorkflowThread,
-               "upload"=>Upload,
-               "task_prototype" => TaskPrototype, 
-               "touch" => Touch }
+               "upload"=>Upload }
 
     query = models[args[:model]]
-    
+
     if(query)
       query = query.includes(args[:includes]) if args[:includes]
       query = query.limit(args[:limit]) if args[:limit]
@@ -74,6 +72,11 @@ module ApiFind
             add [{file_name =>file_contents}]
           end
         end
+      end
+    elsif args[:model]=='url_for_upload'
+      upload = Upload.find(args[:where][:id])
+      if upload
+        add [upload.url]
       end
     end
     #if args[:model] == "job"


### PR DESCRIPTION
Add a method in api find so that the user is able to query the url for a particular upload file. This will enable applications that use Aquarium API to do downstream analysis to download uploaded file from script. For example, the cytometry analysis package Cowfish will be able to download the uploaded zip file from protocol in python and do analysis without requiring user to manually download the file. Tested on my local server and should be safe to merge.
