### PR TITLE
Make tasks menu scrollable

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -388,3 +388,9 @@ img {
 .aquarium-version {
   color: #666;
 }
+
+.scrollable-menu {
+    height: auto;
+    max-height: 550px;
+    overflow-x: hidden;
+}

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -44,7 +44,7 @@
 
           <li id="fat-menu" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tasks<b class="caret"></b></a>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu scrollable-menu">
               <% TaskPrototype.order(:name).each do |tp| %>
                 <% name = pluralize(2,tp.name)[2..-1] %>
                 <li><%= link_to name, tasks_path(task_prototype_id: tp.id) %></li>


### PR DESCRIPTION
Tasks menu has been too long to see on a laptop, I made the Tasks menu scrollable in this pull request. I have tested this both on my laptop and on BIOFAB screen monitor, works fine.
