### PR TITLE
Primer Order shipping costs

### DIFF
--- a/app/accounting/cost_model.rb
+++ b/app/accounting/cost_model.rb
@@ -66,12 +66,12 @@ module CostModel
 
       when ["sequencing","send to sequencing"]
         n = 0
-        if simple_spec[:num_colonies]
+        if simple_spec[:num_colonies] # its a "Plasmid Verification" task
           m = simple_spec[:num_colonies].length
           (0..m-1).each do |i|
-            n += simple_spec[:num_colonies][i] * simple_spec[:primer_ids][i]
+            n += simple_spec[:num_colonies][i] * simple_spec[:primer_ids][i].length
           end
-        else
+        else # its a "Sequencing" task
           simple_spec[:primer_ids].each do |primer_list|
             n += primer_list.length
           end          

--- a/app/accounting/cost_service.rb
+++ b/app/accounting/cost_service.rb
@@ -31,6 +31,8 @@ module CostService
           raise "Could not charge account for #{self.description job, status}: #{row.errors.full_messages.join(',')}" 
         end
 
+        row
+
       end
 
     end


### PR DESCRIPTION
Allows tasks_inputs.rb to submit proper Direct Purchase tasks that jive with cost_model.rb (for the moment, only used for charging for Primer Order shipping costs).
