### PR TITLE
changing how labor is calculated

### DIFF
--- a/app/accounting/cost_model.rb
+++ b/app/accounting/cost_model.rb
@@ -200,7 +200,7 @@ module CostModel
       when ["direct_purchase", "purchased"]
         {
           materials: simple_spec[:materials],
-          labor: simple_spec[:labor] * labor_rate
+          labor: simple_spec[:labor] / labor_rate
         }
       when ["tasks_inputs", "purchased"]
         {


### PR DESCRIPTION
The labor was being calculated incorrectly--we were multiplying by the labor rate rather than dividing.