### PR TITLE
fixed new_collection

### DIFF
--- a/lib/krill/inventory.rb
+++ b/lib/krill/inventory.rb
@@ -41,8 +41,8 @@ module Krill
       Item.make( { quantity: 1, inuse: 0 }, sample: s, object_type: ot )
     end
 
-    def new_collection name, r, c
-      Collection.new_collection name, r, c
+    def new_collection name
+      Collection.new_collection name
     end
 
     def collection_from id


### PR DESCRIPTION
This is a fix for the new_collection Krill method so that it works now that collection rows and columns are associated with the Object Type model.