### PR TITLE
Fix to retrieve with position_as_hash

### DIFF
--- a/app/krill/field_value_krill.rb
+++ b/app/krill/field_value_krill.rb
@@ -26,7 +26,7 @@ module FieldValueKrill
         @item = items[0]
         self.child_item_id = @item.id
         if @item.class == Collection
-          p = @item.position self.child_sample
+          p = @item.position_as_hash self.child_sample
           self.row = p[:row]
           self.column = p[:column]
         end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -21,8 +21,7 @@ class Collection < Item
   end
 
   def position s
-    pos = self.find self.to_sample_id(s)
-    pos.first
+    self.find(s).first
   end
 
   def position_as_hash s


### PR DESCRIPTION
With my initial Collection update, I accidentally had “position” return
[r,c] instead of {row: r, column: c}. This fixes field_value_krill
retrieve model that I broke with the change in return value.

I hope this fixes the last bug I created with the Collection model update.