### PR TITLE
fix occasional bad links in header buttons

### DIFF
--- a/app/views/layouts/_aq2header.html.erb
+++ b/app/views/layouts/_aq2header.html.erb
@@ -82,17 +82,17 @@
         <%= link_to "Planner", launcher_path %>
       </md-button>
 
-      <md-button href="operations" aria-label="Manager" class="main-button <%= yield(:title) == 'Manager' ? 'underlined' : '' %>">
+      <md-button href="/operations" aria-label="Manager" class="main-button <%= yield(:title) == 'Manager' ? 'underlined' : '' %>">
         <%= link_to "Manager", operations_path %>
       </md-button>      
 
-      <md-button href="browser" aria-label="Inventory" class="main-button <%= yield(:title) == 'Inventory' ? 'underlined' : '' %>">
+      <md-button href="/browser" aria-label="Inventory" class="main-button <%= yield(:title) == 'Inventory' ? 'underlined' : '' %>">
         <a href="/browser">Inventory</a>
       </md-button>
 
       <% if current_user && current_user.is_admin %>        
 
-        <md-button href="operation_types" aria-label="Developer" class="main-button <%= yield(:title) == 'Developer' ? 'underlined' : '' %>">
+        <md-button href="/operation_types" aria-label="Developer" class="main-button <%= yield(:title) == 'Developer' ? 'underlined' : '' %>">
           <%= link_to "Developer", operation_types_path %>
         </md-button>
 


### PR DESCRIPTION
For example, clicking the Manager button (not the text) in the header while viewing a job would link to /krill/operations, when it should've linked to /operations.