### PR TITLE
op.temporary short hand

### DIFF
--- a/app/models/operation.rb
+++ b/app/models/operation.rb
@@ -342,7 +342,11 @@ class Operation < ActiveRecord::Base
 
     return true
 
-  end  
+  end
+
+  def tmp
+    self.temporary
+  end
 
   def temporary
     @temporary ||= {}


### PR DESCRIPTION
Convenience for “op.temporary”, which is too long to type over and over
again. “op.tmp” is shorter and easier to type.