### PR TITLE
added debugging library by default

### DIFF
--- a/lib/tasks/default.rb
+++ b/lib/tasks/default.rb
@@ -2,7 +2,11 @@
 # access the inputs and outputs of the operations associated with a job.
 # Add specific instructions for this protocol!
 
+needs "Standard Libs/Debug"
+
 class Protocol
+
+  include Debug
 
   def main
 


### PR DESCRIPTION
The Debug library is useful and perhaps should eventually be integrated into the aquarium source code. For now, it's WIP, so it's nice to keep it as a library.