### PR TITLE
Change operation status finish method

### DIFF
--- a/app/helpers/operation_status.rb
+++ b/app/helpers/operation_status.rb
@@ -63,7 +63,7 @@ module OperationStatus
   end
 
   def finish
-    change_status "done" if self.status != "error"
+    change_status "done" if self.status == "running"
   end
 
   def error error_type, msg


### PR DESCRIPTION
Change operation status finish method so that only transitions when status is running,
rather than not error. Want to prevent overwrite of manually set `"pending"` status within protocol.

Courtesy of @Gamemackerel 