### PR TITLE
Refactor invoice views to split out labor and materials

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -17,12 +17,12 @@ class InvoicesController < ApplicationController
       user = current_user
     end
 
-    @data = (1..12).collect { |m| 
+    @monthly_invoices = (1..12).collect { |m|
       { 
         month: m,
         year: year,
         date: DateTime.new(year,m),
-        entries: Account.users_and_budgets(year, m,user)
+        entries: Account.users_and_budgets(year, m, user)
       }
     }.reverse.reject { |d| d[:entries].length == 0 }
 
@@ -38,6 +38,8 @@ class InvoicesController < ApplicationController
     @rows = @invoice.rows
     @operation_types = OperationType.all
     @base = Account.total(@rows,false)
+    @base_labor = Account.total(@rows.select { |row| row.category == "labor" }, false)
+    @base_materials = Account.total(@rows.select { |row| row.category == "materials"}, false)
     @total = Account.total(@rows,true)
     @markup = @total - @base
     respond_to do |format|

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -47,17 +47,16 @@ class Account < ActiveRecord::Base
     end_date = start_date.next_month
 
     if user
-      rows = Account.where("? <= created_at AND created_at < ? AND user_id = ?", start_date, end_date, user.id)
+      accounts = Account.where("? <= created_at AND created_at < ? AND user_id = ?", start_date, end_date, user.id)
     else  
-      rows = Account.where("? <= created_at && created_at < ?", start_date, end_date)
+      accounts = Account.where("? <= created_at && created_at < ?", start_date, end_date)
     end
 
-    a = rows.collect { |a| { 
-            user_id: a.user_id,
-            budget_id: a.budget_id
-          } 
-        }
-       .uniq
+    a = accounts.collect { |account| {
+            user_id: account.user_id,
+            budget_id: account.budget_id
+          }
+        }.uniq
 
     a.collect { |x| 
 
@@ -67,6 +66,8 @@ class Account < ActiveRecord::Base
         user: User.find(x[:user_id]),
         budget: Budget.find(x[:budget_id]),
         invoice: invoice,
+        spent_materials: Account.total(invoice.rows.select { |row| row.category == "materials"}, false),
+        spent_labor: Account.total(invoice.rows.select { |row| row.category == "labor" }, false),
         spent: Account.total(invoice.rows)
       }
 

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -34,16 +34,16 @@
 
 <% content_for :sidebar do %>
 
-  <md-list ng-init="status.month = '<%= @data[0][:date] %>'">
+  <md-list ng-init="status.month = '<%= @monthly_invoices[0][:date] %>'">
 
-    <% @data.each do |datum| %>
+    <% @monthly_invoices.each do |invoices| %>
 
-      <md-list-item ng-click="status.month = '<%= datum[:date] %>'"
-                    ng-class="status.month == '<%= datum[:date] %>' ? 'md-body-2 selected-view' : 'md-body-2'">
-        <p><%= datum[:date].strftime("%B %Y") %></p>
+      <md-list-item ng-click="status.month = '<%= invoices[:date] %>'"
+                    ng-class="status.month == '<%= invoices[:date] %>' ? 'md-body-2 selected-view' : 'md-body-2'">
+        <p><%= invoices[:date].strftime("%B %Y") %></p>
         <span>
         <% if params[:all] %>
-          <%= number_to_currency(datum[:entries].collect { |e| e[:spent] }.inject{|s,x| s + x}) %>
+          <%= number_to_currency(invoices[:entries].collect { |e| e[:spent] }.inject{|s,x| s + x}) %>
         <% end %>
         </span>
       </md-list-item>
@@ -56,33 +56,49 @@
 
 <%= content_for :main do %>
 
-  <% @data.each do |datum| %>
+  <% @monthly_invoices.each do |invoices| %>
 
-    <md-content layout-padding ng-show="status.month == '<%= datum[:date] %>'">
+    <md-content layout-padding ng-show="status.month == '<%= invoices[:date] %>'">
 
       <h3>
-        <%= datum[:date].strftime("%B %Y") %>
+        <%= invoices[:date].strftime("%B %Y") %>
         <% if params[:all] %>
-          : <%= number_to_currency(datum[:entries].collect { |e| e[:spent] }.inject{|s,x| s + x}) %>
+          : <%= number_to_currency(invoices[:entries].collect { |e| e[:spent] }.inject{|s,x| s + x}) %>
         <% end %>
       </h3>
 
-      <% datum[:entries].collect { |e| e[:budget] }.uniq.each do |b| %>
+      <% invoices[:entries].collect { |account| account[:budget] }.uniq.each do |b| %>
 
         <p class='indent budget-name'><b><%= link_to b.name, b %></b> (<%= b.contact %>): <%= b.description %> </p>
 
         <table class='table table-condensed users' style="table-layout: fixed">
-          <% datum[:entries].select { |e| e[:budget].id == b.id }.each do |e| %>
+          <tr>
+            <th></th>
+            <th></th>
+            <th>Labor</th>
+            <th>Materials</th>
+            <th>Overhead</th>
+            <th>Total</th>
+          </tr>
+          <% invoices[:entries].select { |account| account[:budget].id == b.id }.each do |entry| %>
             <tr>
-              <td><%= e[:user].name %> (<%= link_to "#{e[:user].login}", e[:user] %>)</td>
-              <td><i><%= e[:invoice].in_progress ? "in progress" : e[:invoice].status %></i></td>
-              <td><%= link_to number_to_currency(e[:spent]), e[:invoice] %></td>        
+              <td><%= entry[:user].name %> (<%= link_to "#{entry[:user].login}", entry[:user] %>)</td>
+              <td><i><%= entry[:invoice].in_progress ? "in progress" : entry[:invoice].status %></i></td>
+              <td><%= number_to_currency(entry[:spent_labor]) %></td>
+              <td><%= number_to_currency(entry[:spent_materials]) %></td>
+              <td><%= number_to_currency(entry[:spent] - (entry[:spent_labor] + entry[:spent_materials])) %></td>
+              <td><%= link_to number_to_currency(entry[:spent]), entry[:invoice] %></td>
             </tr>
           <% end %>
-          <% total = datum[:entries].select { |e| e[:budget].id == b.id }.collect { |e| e[:spent] }.inject{|sum,x| sum+x} %>
+          <% total_labor = invoices[:entries].select { |e| e[:budget].id == b.id }.collect { |e| e[:spent_labor] }.inject{|sum,x| sum+x} %>
+          <% total_materials = invoices[:entries].select { |e| e[:budget].id == b.id }.collect { |e| e[:spent_materials] }.inject{|sum,x| sum+x} %>
+          <% total = invoices[:entries].select { |e| e[:budget].id == b.id }.collect { |e| e[:spent] }.inject{|sum,x| sum+x} %>
           <tr>
           <td></td>
           <td></td>
+            <td><b><%= number_to_currency(total_labor) %></b></td>
+            <td><b><%= number_to_currency(total_materials) %></b></td>
+            <td><b><%= number_to_currency(total - (total_labor + total_materials)) %></b></td>
           <td><b><%= number_to_currency(total) %></b></td>
           </tr>
         </table>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -22,7 +22,9 @@
 
   <hr>
 
-  <b>Base Cost</b>: <%= number_to_currency(@base) %><br />
+    <b>Base Cost</b>: <%= number_to_currency(@base) %><br />
+    <b>Base Materials</b>: <%= number_to_currency(@base_materials) %><br />
+    <b>Base Labor</b>: <%= number_to_currency(@base_labor) %><br />
   <b>Operating Costs</b>: <%= number_to_currency(@markup) %><br />
   <b>Total</b>: <%= number_to_currency(@total) %>
 


### PR DESCRIPTION
Changes how invoices are displayed so that costs for labor, materials and overhead are split out.  
This is our solution to handling [cost-only budgets](https://github.com/klavinslab/aquarium-bugs/issues/183).