### PR TITLE
add static inputs to operations

### DIFF
--- a/lib/krill/operation_list.rb
+++ b/lib/krill/operation_list.rb
@@ -233,6 +233,19 @@ module Krill
 
     end
 
+    def add_static_inputs name, sample_name, container_name
+      
+      self.each do |op|
+        sample = Sample.find_by_name(sample_name)
+        container = ObjectType.find_by_name(container_name)
+        op.add_input name, sample, container
+        op.input(name).set item: sample.in(container.name).first
+      end
+    
+      self
+
+    end
+
   end
   
 end


### PR DESCRIPTION
An example of this in use would be
```ruby
operations.add_static_inputs "Cut Smart", "Cut Smart", "Enzyme Buffer Stock"
          .add_static_inputs "PmeI", "PmeI", "Enzyme Stock"
```

A more complete description (and a more general feature request) can be found in klavinslab/aquarium-bugs#252