### PR TITLE
remove arrow key control of tech interface

### DIFF
--- a/app/assets/javascripts/ng-control/technician.js
+++ b/app/assets/javascripts/ng-control/technician.js
@@ -121,14 +121,12 @@
 
       switch(evt.key) {
 
-        case "ArrowLeft":
-        case "ArrowUp":
+        case "PageUp":
           if ( $scope.job.state.index > 0 ) {
             $scope.job.state.index--;
           }
           break;
-        case "ArrowRight":
-        case "ArrowDown":
+        case "PageDown":
           if ( $scope.job.state.index < $scope.job.backtrace.length - 1 ) {
             $scope.job.state.index++;
           } else {


### PR DESCRIPTION
This removes arrow key control of moving back and forward in a protocol in the tech interface. "PageUp" now goes back and "PageDown" goes forward.