### PR TITLE
Add technician footpedal interface

### DIFF
--- a/app/assets/javascripts/ng-control/technician.js
+++ b/app/assets/javascripts/ng-control/technician.js
@@ -1,6 +1,21 @@
 (function() {
   var w = angular.module("aquarium");
 
+  w.directive('focusedWhen', function() {
+    return {
+      scope: {
+        focusedWhen: '=',
+      },
+      link: function($scope, $element) {
+        $scope.$watch('focusedWhen', function(shouldFocus) {
+          if (shouldFocus) {
+            $element[0].focus();
+          }
+        });
+      }
+    };
+  });
+
   w.controller("technicianCtrl", [
     "$scope",
     "$http",
@@ -136,15 +151,15 @@
       };
 
       $scope.keyDown = function(evt) {
-        console.log(evt.key, evt);
-
         switch (evt.key) {
           case "PageUp":
+            event.preventDefault();
             if ($scope.job.state.index > 0) {
               $scope.job.state.index--;
             }
             break;
           case "PageDown":
+            event.preventDefault();
             if ($scope.job.state.index < $scope.job.backtrace.length - 1) {
               $scope.job.state.index++;
             } else {
@@ -153,7 +168,24 @@
             break;
           case "a":
             if (evt.ctrlKey) {
+              event.preventDefault();
               $scope.job.backtrace.last.check_all();
+            }
+            break;
+          case "End":
+            event.preventDefault();
+            document.getElementById('content-container').focus();
+            if ($scope.job.state.index < $scope.job.backtrace.length - 1) {
+              $scope.job.state.index++;
+            } else if (!$scope.job.backtrace.last.check_next()) {
+              $scope.ok();
+            }
+            break;
+          case "Home":
+            event.preventDefault();
+            document.getElementById('content-container').focus();
+            if(!$scope.job.backtrace.last.uncheck_prev() && $scope.job.state.index > 0) {
+              $scope.job.state.index--;
             }
 
           default:

--- a/app/views/technician/_show_block.html.erb
+++ b/app/views/technician/_show_block.html.erb
@@ -44,7 +44,8 @@
       <md-input-container class="select-container">
         <md-select ng-model="step.response.inputs[line.select.var]"
                    aria-label="Select"
-                   ng-disabled="!step.response.in_progress">
+                   ng-disabled="!step.response.in_progress"
+                   focused-when="line.focused">
           <md-option ng-repeat="c in content_value(line).choices" ng-value="c">
             {{c}}
           </md-option>
@@ -64,11 +65,13 @@
                ng-if="content_value(line).type == 'number'"
                type = 'number'
                ng-model="step.response.inputs[line.input.var]"
-               ng-disabled="!step.response.in_progress">
+               ng-disabled="!step.response.in_progress"
+               focused-when="line.focused">
         <input class="md-subhead"
                ng-if="content_value(line).type != 'number'"
                ng-model="step.response.inputs[line.input.var]"
-               ng-disabled="!step.response.in_progress">
+               ng-disabled="!step.response.in_progress"
+               focused-when="line.focused">
       </div>
       {{content_value(line).type}}
     </md-input-container>
@@ -160,7 +163,8 @@
                  ng-model="step.response.inputs.table_inputs[cell.key][cell.operation_id].value"
                  data-opid="{{cell.operation.id}}"
                  class="krill-table-input"
-                 ng-disabled="!step.response.in_progress">
+                 ng-disabled="!step.response.in_progress"
+                 focused-when="cell.focused">
           <span ng-if="!cell.type && cell.content == undefined"><span ng-bind-html="sce(cell)"></span></span>
           <span ng-if="!cell.type && cell.content != undefined && ( !cell.check || !step.response.in_progress )">
             <span ng-bind-html="sce(cell.content)"></span>


### PR DESCRIPTION
* Add new notion of 'substeps' for steps in the technician interface: all components of a step that require clicks or input from user (check, select, get).
* Add two new technician hotkeys (home, end) which allow tech to travel over the substeps in either direction. These hotkeys can be easily set as the emulated keyboard input from most usb or bluetooth footpedals.
* Add 'event.preventDefault();' to all new and existing technician hotkeys to prevent double-behavior.