### PR TITLE
Add technician dashboard

### DIFF
--- a/app/assets/javascripts/ng-control/technician_dashboard.js
+++ b/app/assets/javascripts/ng-control/technician_dashboard.js
@@ -1,0 +1,209 @@
+(function () {
+
+  let w = angular.module('aquarium');
+
+  w.controller('technicianDashboard', ['$scope', '$http', '$attrs', '$interval', '$mdDialog',
+                        function ($scope,    $http,   $attrs,   $interval,   $mdDialog) {
+
+      AQ.init($http);
+      AQ.update = () => { $scope.$apply(); };
+      AQ.confirm = (msg) => { return confirm(msg); };
+      AQ.config.no_items_in_backtrace = true;
+
+      $scope.operation_types = [];
+
+      function category_index(c) {
+        $scope.categories.indexOf(c);
+      }
+
+      function get_category(i) {
+        $scope.categories[i];
+      }
+
+      function init1() {
+
+        $scope.current = {
+          status: 'scheduled',
+          category_index: null,
+          operations: [],
+        }
+
+        $interval(reload, 30000);
+
+      }
+
+      function get_numbers() {
+        return AQ.OperationType.numbers($scope.current.selected_user, $scope.current.filter_user)
+      }
+
+      $scope.get_numbers = get_numbers;
+
+      init1();
+
+      function get_running_jobs() {
+        AQ.Job.where("pc >= 0", { include: [ { operations: { include: "operation_type" } }, "user" ] }).then(jobs => {
+          AQ.http.get("/krill/jobs").then(response => {
+            $scope.running_jobs = jobs.reverse();
+            $scope.krill_job_ids = response.data.jobs;
+          });
+        });
+      }
+
+      get_running_jobs();
+
+      $scope.status_selector = function (operation_type, status) {
+        var selector = "";
+        if ($scope.numbers[operation_type.id]) {
+          if (!$scope.numbers[operation_type.id][status] || $scope.numbers[operation_type.id][status] === 0) {
+            selector += " number-none";
+          } else {
+            selector += " number-some";
+          }
+          if ($scope.current.operation_type === operation_type && $scope.current.status === status) {
+            selector += " number-selected"
+          } else {
+            selector += " number";
+          }
+        } else {
+          selector += " number-none";
+        }
+        return selector;
+      };
+
+      function highlight_categories(numbers) {
+        $scope.current.active = {};
+        for ( var n in numbers ) {
+          aq.each($scope.operation_types, operation_type => {
+            if ( operation_type.id == n && numbers[n].scheduled > 0 ) {
+              $scope.current.active[operation_type.category] = true;
+              if ( !$scope.current.category_index ) {
+                $scope.current.category_index = $scope.categories.indexOf(operation_type.category)
+              }
+            }
+          })
+        }
+      }
+
+      $scope.select_category = function(cat_index, status, selected_ops, append=false) {
+        if (!append) {
+          $scope.current.status = status;
+          $scope.current.category_index = cat_index
+          delete $scope.current.operations;
+        }
+        delete $scope.jobs;
+
+        let operations = $scope.current.operations
+
+        category = get_category(cat_index)
+        let ot_ids = aq.where($scope.operation_types, ot => ot.category == $scope.categories[$scope.current.category_index]).map(ot => ot.id);
+        console.log(ot_ids)
+        // debugger;
+        let criteria = {
+          operation_type_id: ot_ids,
+          status: 'scheduled'
+        };
+        // let options = {reverse: true};
+        let options = {};
+
+        AQ.Operation.manager_list(criteria, options).then(operations => {
+          aq.each(operations, op => {
+            op.jobs = aq.collect(op.jobs, job => AQ.Job.record(job));
+            op.field_values = aq.collect(op.field_values, fv => AQ.FieldValue.record(fv))
+          });
+          $scope.current.operations = operations;
+          aq.each(operations, op => {
+            aq.each(selected_ops, sop => {
+              if (op.id === sop.id) {
+                op.selected = true;
+              }
+            })
+          });
+
+          jobs_with_duplicates = aq.collect(operations, op => {
+            return op.jobs.length > 0 ? op.last_job : null
+          });
+
+          $scope.jobs = uniquify_by_id(jobs_with_duplicates);
+          $scope.$apply();
+        });
+      }
+
+      $scope.status = 'Loading Operation Types ...';
+
+      AQ.OperationType.deployed_with_timing().then(operation_types => {
+        $scope.status = "Fetching user information ...";
+        AQ.User.current().then(user => {
+          AQ.User.active_users().then(users => {
+            $scope.users = users;
+            get_numbers().then(numbers => {
+
+              $scope.status = "Ready";
+              AQ.operation_types = AQ.OperationType.sort_by_timing(operation_types);
+              $scope.operation_types = AQ.operation_types;
+              aq.each($scope.operation_types, operation_type => {
+                operation_type.list = {
+                  done: { offset: 0, limit: 10 },
+                  error: { offset: 0, limit: 10 }
+                };
+                operation_type.timing = AQ.Timing.record(operation_type.timing);
+              });
+              $scope.categories = aq.uniq(aq.collect(operation_types, operation_type => operation_type.category)).sort();
+              $scope.current_user = user;
+              $scope.numbers = numbers;
+              highlight_categories(numbers);
+              $scope.select_category($scope.current.category_index, $scope.current.status, $scope.current.operations)
+              $scope.$apply();
+            });
+          });
+        });
+      });
+
+      function uniquify_by_id(list) {
+        results = []
+        const map = new Map();
+        for (const item of list) {
+          if(!map.has(item.id)){
+            map.set(item.id, true);
+            results.push(item);
+          }
+        }
+        return results;
+      }
+
+      $scope.more = function (status) {
+        $scope.current.operation_type.list[status].offset += 10;
+        $scope.select_category(scope.current.category_index, status, [], true);
+      };
+
+      function reload() {
+        $scope.select_category($scope.current.category_index, $scope.current.status, [])
+        get_running_jobs();        
+      }
+
+      $scope.choose = function (operation_type, status, val, job_id) {
+        aq.each(operation_type.operations, operation => {
+          if (operation.operation_type_id === operation_type.id && operation.status === status && (!job_id || operation.last_job.id === job_id)) {
+            operation.selected = val;
+          }
+        });
+      };
+
+      $scope.category_class = function(index) {
+
+        let c = "no-highlight";
+
+        if ( $scope.current.category_index == index ) {
+          c += ' selected-category';
+        } else {
+          c += ' unselected-category';
+        }
+
+        if ( $scope.current.active[$scope.categories[index]] ) {          
+          c += " active-category";
+        }
+
+        return c;
+
+      }
+    }]);
+})();

--- a/app/assets/stylesheets/operation.css.scss
+++ b/app/assets/stylesheets/operation.css.scss
@@ -10,6 +10,14 @@
     width: 30%;
   }
 
+  .category-container-full {
+    padding-top: 4px;
+    padding-right: 8px;
+    /*border-right: 1px solid #eee;*/
+    /*border-bottom: 2px solid #eee;*/
+    width: 100%;
+  }
+
   .selected-category, .unselected-category {
     cursor: pointer;
     font-size: 9pt;

--- a/app/controllers/technician_dashboard_controller.rb
+++ b/app/controllers/technician_dashboard_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TechnicianDashboardController < ApplicationController
+
+  before_filter :signed_in_user
+  before_filter :up_to_date_user
+
+  def index
+    respond_to do |format|
+      format.json do
+        render json: Operation.where(status: %w[pending scheduled running primed])
+                              .as_json(methods: %i[field_values plans precondition_value])
+      end
+      format.html { render layout: 'aq2' }
+    end
+  end
+end

--- a/app/views/layouts/_aq2header.html.erb
+++ b/app/views/layouts/_aq2header.html.erb
@@ -104,6 +104,14 @@
         <%= link_to "Plans", launcher_path %>
       </md-button>
 
+
+      <% if Bioturk::Application.config.technician_dashboard %>
+        <md-button href="/technician_dashboard" aria-label="Technician"
+                   class="main-button <%= yield(:title) == 'Technician' ? 'underlined' : '' %>">
+          <%= link_to "Technician", '/technician_dashboard' %>
+        </md-button>
+      <% end %>
+
       <md-button href="/operations" aria-label="Manager"
                  class="main-button <%= yield(:title) == 'Manager' ? 'underlined' : '' %>">
         <%= link_to "Manager", operations_path %>

--- a/app/views/technician_dashboard/_operation_list.html.erb
+++ b/app/views/technician_dashboard/_operation_list.html.erb
@@ -1,0 +1,143 @@
+<script type="text/ng-template" id="operation-list">
+
+  <div class='oplist'>
+
+    <table class='table table-condensed oplist'
+           ng-show="operations.length > 0">
+
+      <tr>
+        <th class='selector'></th>
+        <th class='id'>Op Id</th>
+        <th>User</th>
+        <th class="output">Data</th>
+        <th>Job(s)</th>
+        <th>Plan</th>
+        <th>Last Update</th>
+      </tr>
+
+      <tr ng-repeat="op in operations"
+          ng-if="!jobid || op.last_job.id == jobid">
+
+        <td>
+        </td>
+
+        <td>{{op.id}}</td>
+
+        <td>{{op.user.name}}</td>
+
+        <td>
+          <ul class='input-list'>
+            <li ng-repeat="fv in op.field_values | filter: { role: 'output' } track by $index">
+              <span ng-if="$first"  style="width: 26px; display: inline-block"><b>out:</b></span>
+              <span ng-if="!$first" style="width: 26px; display: inline-block">&nbsp;</span>
+              {{fv.name}}
+              <span ng-if="fv.sample">: 
+                <a href="/browser?sid={{fv.sample.id}}" target="samples">{{fv.sample.id}}: {{fv.sample.name}}</a>
+                <span ng-if="fv.item.object_type"> as {{fv.item.object_type.name}}</span>
+                <span ng-if="fv.child_item_id">
+                  ( 
+                    <div ng-if="fv.child_item_id && !fv.is_part"
+                         item="fv.item" 
+                         container="fv.item.object_type" 
+                         sample="fv.sample"></div>
+                    <div ng-if="fv.child_item_id && fv.is_part"
+                         item="fv.part" 
+                         container="fv.part.object_type" 
+                         sample="fv.part.sample"
+                         collection="fv.item"
+                         row="fv.row"
+                         column=fv.column></div>
+                  )
+                </span>                
+              </span>
+            </li>
+            <li ng-repeat="fv in op.field_values | filter: { role: 'input' } track by $index">
+              <span ng-if="$first"  style="width: 18px; display: inline-block"><b>in:</b></span>
+              <span ng-if="!$first" style="width: 18px; display: inline-block">&nbsp;</span>
+              {{fv.name}}
+              <span ng-if="fv.sample">: 
+                <a href="/browser?sid={{fv.sample.id}}" target="samples">{{fv.sample.id}}: {{fv.sample.name}}</a>
+                <span ng-if="fv.child_item_id">
+                  ( 
+                    <div ng-if="fv.child_item_id && !fv.is_part"
+                         item="fv.item" 
+                         container="fv.item.object_type" 
+                         sample="fv.sample"></div>
+                    <div ng-if="fv.child_item_id && fv.is_part"
+                         item="fv.part" 
+                         container="fv.part.object_type" 
+                         sample="fv.part.sample"
+                         collection="fv.item"
+                         row="fv.row"
+                         column=fv.column></div>
+                  )
+                </span>
+              </span>
+              <span ng-if="fv.value">{{fv.value}}</span>
+            </li>      
+            <li ng-repeat="da in op.data_associations">
+                <b>{{da.key}}:</b> {{da.value}}
+            </li>
+          </ul>
+        </td>
+
+        <td>
+          <div ng-if="op.jobs.length > 0" ng-repeat="job in op.jobs">
+            <a href="/jobs/{{job.id}}">{{job.id}}</a> (<span>{{job.status}}</span>)
+          </div>
+          <div ng-if="op.jobs.length == 0">--</div>          
+        </td>
+
+        <td>
+          <a ng-repeat="plan in op.plans" href="/plans?plan_id={{plan.id}}" target="designer">{{plan.id}}{{$last ? '' : ', '}}</a>
+          <span ng-if="op.plans.length == 0">n/a</span>
+        </td>
+
+        <td>{{op.updated_at|date}}</td>
+
+        <% if current_user && current_user.is_admin %>
+
+          <td ng-if="op.status != 'scheduled' && op.status != 'running'">
+
+            <md-menu layout="row">
+
+              <span ng-click="$mdMenu.open($event)"
+                    style="color: #333; font-size: 9pt; cursor: pointer"
+                    class="no-highlight">
+                <md-tooltip md-direction="bottom" md-delay="2500">Force operation to a different status.</md-tooltip>
+                {{op.status}}&#9660;
+              </span>
+
+              <md-menu-content width="4">
+                <md-menu-item ng-repeat="s in ['waiting', 'pending', 'deferred', 'primed', 'delayed', 'done', 'error']" ng-if="op.status != s">
+                  <md-button ng-click="change_status(op,s)" aria-label="Change to {{s}}">
+                    {{s}}
+                  </md-button>
+                </md-menu-item>           
+              </md-menu-content>
+
+            </md-menu>
+
+          </td>
+
+        <% end %>
+
+      </tr>
+
+      <tr ng-if="( status == 'error' || status == 'done' ) && operations.length < $parent.$parent.numbers[operationtype.id][status]">
+        <td></td>
+        <td colspan=5 style='padding-top: 16px'>
+          <md-button class='md-raised md-primary md-small' 
+                     ng-click="$parent.$parent.more(status)">More</md-button>
+        </td>
+      </tr>
+
+    </table>
+
+    <h1 ng-if="operations.length == 0" class='md-title'>No operations</h1>
+
+    <h1 ng-if="!operations" class='md-title'>Checking for operations...</h1>
+
+  </div>
+
+</script>

--- a/app/views/technician_dashboard/_sidebar.html.erb
+++ b/app/views/technician_dashboard/_sidebar.html.erb
@@ -1,0 +1,13 @@
+<div layout="row">
+  <div layout="column" class="category-container-full">
+
+      <div ng-repeat="cat in categories track by $index"
+          ng-click="current.switch_user = false;
+                    current.active_jobs = false;
+                    select_category($index, 'scheduled', [])"
+           ng-class="category_class($index)"
+           ng-attr-data-category-choice="{{cat}}">
+          {{cat}}
+      </div>           
+  </div>
+</div>

--- a/app/views/technician_dashboard/index.html.erb
+++ b/app/views/technician_dashboard/index.html.erb
@@ -1,0 +1,80 @@
+<%= render partial: "/items/template" %>
+<%= render partial: 'operation_list' %> 
+
+<% provide(:title, 'Technician') %>
+
+<%= content_for :class do %>operations<% end %>
+
+<%= content_for :controller do %>technicianDashboard<% end %>
+
+<%= content_for :sidebar do %>
+
+  <div layout='column'>
+    <%= render partial: 'sidebar' %> 
+  </div>
+
+<% end %>
+
+<%= content_for :specific_title do %>
+
+  <span class='capitalize'>
+    &rang; {{categories[current.category_index]}} &rang; {{current.status}} 
+  </span>
+
+<% end %>
+
+<%= content_for :main do %>
+
+   <%= render partial: '/data_associations/template' %> 
+
+   <div ng-if="!current.activity_report.selected">
+
+     <div class='timing md-subhead timing-info'
+          ng-if="current.operation_type.timing && current.operation_type.timing.active">
+          Usually Scheduled {{current.operation_type.timing.as_string}}
+     </div>
+
+    <div ng-if="current.status == 'scheduled' || current.status == 'running'">
+
+      <div ng-if="jobs.length > 0" ng-repeat="job in jobs" class='job'  style='margin: 16px'>
+
+        <md-toolbar class="job-toolbar">
+
+          <div class='md-toolbar-tools'>
+
+            <h2 flex md-truncate>
+              Job <a href="/jobs/{{job.id}}">{{job.id}}</a>
+              <span ng-if="debugging_job_id == job.id">
+                <md-progress-circular class="md-hue-2" md-diameter="20px" style="display: inline-block">
+                </md-progress-circular> 
+              </span>
+              <span style="padding: 15%">{{job.type}}</span>
+            </h2>
+          
+            <% if current_user %>
+              <md-button ng-if="current.status != 'running'"
+                         class='md-small'
+                         ng-href="/krill/start?job={{job.id}}"
+                         aria-lable="Run"
+                         data-manager-job-action="run">Run</md-button>
+            <% end %>
+          </div>
+
+        </md-toolbar>
+
+        <oplist operations="current.operations"
+                status="current.status" 
+                jobid="job.id">
+        </oplist>
+
+      </div>
+
+      <h1 class="md-title" ng-if="jobs.length == 0">No Jobs</h1>
+
+      <h1 class="md-title" ng-if="!jobs">Loading Jobs ...</h1>    
+
+    </div>
+
+  </div>
+
+<% end %>

--- a/config/initializers/aquarium_template.notrb
+++ b/config/initializers/aquarium_template.notrb
@@ -27,7 +27,7 @@ Bioturk::Application.config.debug_tools = true # false will hide debug buttons i
 Bioturk::Application.config.krill_port = 3500
 Bioturk::Application.config.krill_hostname = 'localhost' # for krill and aq on same server (no docker)
 #Bioturk::Application.config.krill_hostname = 'krill' # for krill docker container
-
+Bioturk::Application.config.technician_dashboard = false # false will hide the technician view dashboard from the top nav menu
 
 #
 # Set CSRF token names

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,8 @@ Bioturk::Application.routes.draw do
   get '/operations/:id/retry',                   to: 'operations#retry'
   resources :operations
 
+  resources :technician_dashboard, only: [:index]
+
   get '/operation_types/test_all', to: 'operation_types#test_all'
   post '/operation_types/import',                    to: 'operation_types#import'
   get '/operation_types/numbers/:user_id/:filter',   to: 'operation_types#numbers'


### PR DESCRIPTION
Add a new view that allows technicians to select and run scheduled jobs from different categories without exposing any of the more complicated manager functionality.

To further simplify the view, all jobs are collected together into a single list for each category, labeled by their operation type, rather than having a separate list for each operation type. This simplification increases the the viability of foot pedal navigation for the page.

The dashboard can be configured to appear in aquarium or not via the boolean configuration variable `Bioturk::Application.config.technician_dashboard` set in aquarium.rb

![technician_dashboard](https://user-images.githubusercontent.com/3107677/80650524-ff9c9c00-8a28-11ea-9a51-4960221f3b88.png)
