### PR TITLE
BUG: Create job button not showing on operations with manual status updates

### DIFF
--- a/app/views/operations/index.html.erb
+++ b/app/views/operations/index.html.erb
@@ -32,7 +32,7 @@
     <div ng-if="!current.activity_report.selected">
       <md-button aria-label="Schedule"
                 class='md-raised md-primary'
-                ng-if="!current.operation_type.on_the_fly && current.status == 'pending'"
+                ng-if="current.status == 'pending'"
                 ng-disabled="disable_batch_button()"
                 ng-click="batch(current.operation_type)"
                 data-manager-action="schedule"


### PR DESCRIPTION
The **create job** button was set to hide for "on the fly" status changes.
Fix: update conditional to show for all operations with status pending.