### PR TITLE
sample types backend + updated api call syntax + use database cleaner…

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -28,6 +28,10 @@ gem 'rack-cors'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'factory_bot_rails'
+  gem 'rspec-rails'
+  gem 'simplecov'
+  gem 'database_cleaner-active_record'
 end
 
 group :development do
@@ -35,9 +39,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'factory_bot_rails'
-  gem 'rspec-rails'
-  gem 'simplecov'
   gem 'rubocop'
   gem 'rubocop-rails'
 end

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -64,6 +64,10 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    database_cleaner (1.8.5)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     diff-lcs (1.4.4)
     docile (1.3.2)
     erubi (1.9.0)
@@ -205,6 +209,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
+  database_cleaner-active_record
   factory_bot_rails
   listen (~> 3.2)
   mysql2 (>= 0.4.4)

--- a/backend/app/controllers/api/v3/permissions_controller.rb
+++ b/backend/app/controllers/api/v3/permissions_controller.rb
@@ -5,11 +5,9 @@ module Api
     # PERMISSIONS RELATED API CALLS
     class PermissionsController < ApplicationController
       # GET CURRENT LIST OF PERMISSIONS FROM PERMISSIONS DB
-      def get_permissions
+      def index
         status, response = check_token_for_permission
-        if response[:error]
-          render json: response.to_json, status: status and return 
-        end
+        render json: response.to_json, status: status.to_sym and return if response[:error]
 
         permissions = Permission.permission_ids
 

--- a/backend/app/controllers/api/v3/permissions_controller.rb
+++ b/backend/app/controllers/api/v3/permissions_controller.rb
@@ -7,7 +7,6 @@ module Api
       # Returns the list of permissions.
       #
       # @param token [String] a token
-      #
       # @return the list of permissions
       def index
          # Check for any permissions

--- a/backend/app/controllers/api/v3/permissions_controller.rb
+++ b/backend/app/controllers/api/v3/permissions_controller.rb
@@ -2,10 +2,15 @@
 
 module Api
   module V3
-    # PERMISSIONS RELATED API CALLS
+    # Permissions related api calls
     class PermissionsController < ApplicationController
-      # GET CURRENT LIST OF PERMISSIONS FROM PERMISSIONS DB
+      # Returns the list of permissions.
+      #
+      # @param token [String] a token
+      #
+      # @return the list of permissions
       def index
+         # Check for any permissions
         status, response = check_token_for_permission
         render json: response.to_json, status: status.to_sym and return if response[:error]
 

--- a/backend/app/controllers/api/v3/sample_types_controller.rb
+++ b/backend/app/controllers/api/v3/sample_types_controller.rb
@@ -37,7 +37,7 @@ module Api
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        id = Input.number(params[:id])
+        id = Input.index(params[:id])
 
         # Get sample type
         sample_type = SampleType.find_id(id)
@@ -85,11 +85,11 @@ module Api
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        id = Input.number(params[:id])
+        id = Input.index(params[:id])
 
         # Get sample type
         sample_type = SampleType.find_id(id)
-        render json: { sample_type: nil  }.to_json, status: :ok and return if !sample_type
+        render json: { sample_type: nil }.to_json, status: :ok and return if !sample_type
 
         # Update sample type
         # Note: any errors handled automatically and silently
@@ -108,7 +108,7 @@ module Api
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        id = Input.number(params[:id])
+        id = Input.index(params[:id])
 
         # Get sample type
         sample = SampleType.find_id(id)

--- a/backend/app/controllers/api/v3/sample_types_controller.rb
+++ b/backend/app/controllers/api/v3/sample_types_controller.rb
@@ -2,19 +2,23 @@
 
 module Api
   module V3
-    # SAMPLE TYPE API CALLS
+    # Sample type api calls
     class SampleTypesController < ApplicationController
-      # LIST OF SAMPLE TYPES PLUS DETAILS FOR FIRST ITEM IN LIST
+      # Return all sample types.
+      #
+      # @param token [String] a token
+      #
+      # @return all sample types
       def index
-        # CHECK FOR ADMIN PERMISSIONS
+        # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        # GET LIST
+        # Get list
         list = SampleType.find_all
         render json: { sample_types: nil,  }.to_json, status: :ok and return if list.length == 0
 
-        # GET DETAILS OF FIRST ITEM IN LIST
+        # Get details of first item in list
         details = SampleType.details(list[0].id)
         details = details.update({ id: list[0].id, name: list[0].name })
 
@@ -24,19 +28,24 @@ module Api
          }.to_json, status: :ok
       end
 
-      # DETAILS FOR SELECTED SAMPLE TYPE
+      # Return details for a specific sample type.
+      #
+      # @param token [String] a token
+      # @param id [id] the id of the sample type
+      #
+      # @return the sample type
       def show
-        # CHECK FOR ADMIN PERMISSIONS
+        # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
         id = Input.number(params[:id])
 
-        # GET ITEM
+        # Get item
         sample_type = SampleType.find_id(id)
         render json: { sample_type: nil  }.to_json, status: :ok and return if !sample_type
 
-        # GET DETAILS OF FIRST ITEM IN LIST
+        # Get details of first item in list
         details = SampleType.details(id)
         details = details.update({ id: id, name: sample_type.name, description: sample_type.description })
 
@@ -45,9 +54,16 @@ module Api
          }.to_json, status: :ok
       end
 
-      # CREATE NEW SAMPLE TYPE
+      # Create a new sample type.
+      #
+      # @param token [String] a token
+      # @param name [name] the name of the sample type
+      # @param description [description] the description of the sample type
+      # @param field_types [hash] the :field_types to be used for the allowable_field_types
+      #
+      # @return the sample type
       def create
-        # CHECK FOR ADMIN PERMISSIONS
+        # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
@@ -58,38 +74,51 @@ module Api
 
       end
 
-      # UPDATE SAMPLE TYPE
+      # Update a sample type.
+      #
+      # @param token [String] a token
+      # @param id [Int] the id of the sample type
+      # @param name [name] the name of the sample type
+      # @param description [description] the description of the sample type
+      # @param field_types [hash] the :field_types to be used for the allowable_field_types
+      #
+      # @return the sample type
       def update
-         # CHECK FOR ADMIN PERMISSIONS
+         # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
         id = Input.number(params[:id])
 
-        # GET ITEM
+        # Get item
         sample_type = SampleType.find_id(id)
         render json: { sample_type: nil  }.to_json, status: :ok and return if !sample_type
 
-        # UPDATE SAMPLE
-        # NOTE: ANY ERRORS HANDLED AUTOMATICALLY AND SILENTLY
+        # Update sample
+        # Note: any errors handled automatically and silently
         sample_type = sample_type.update(params)
 
         render json: sample_type.to_json, status: :ok
       end
 
-      # DELETE SAMPLE TYPE
+      # Delete a sample type.
+      #
+      # @param token [String] a token
+      # @param id [Int] the id of the sample type
+      #
+      # @return a success message
       def delete
-        # CHECK FOR ADMIN PERMISSIONS
+        # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
         id = Input.number(params[:id])
 
-        # GET ITEM
+        # Get item
         sample = SampleType.find_id(id)
         render json: { sample_type: nil  }.to_json, status: :ok and return if !sample
 
-        # DELETE ITEM AND RELATED ITEMS WITHOUT FOREIGN KEYS
+        # Delete item and related items without foreign keys
         sample.delete_sample_type
 
         render json: {

--- a/backend/app/controllers/api/v3/sample_types_controller.rb
+++ b/backend/app/controllers/api/v3/sample_types_controller.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    # SAMPLE TYPE API CALLS
+    class SampleTypesController < ApplicationController
+      # LIST OF SAMPLE TYPES PLUS DETAILS FOR FIRST ITEM IN LIST
+      def index
+        # CHECK FOR ADMIN PERMISSIONS
+        status, response = check_token_for_permission(1)
+        render json: response.to_json, status: status.to_sym and return if response[:error]
+
+        # GET LIST
+        list = SampleType.find_all
+        render json: { sample_types: nil,  }.to_json, status: :ok and return if list.length == 0
+
+        # GET DETAILS OF FIRST ITEM IN LIST
+        details = SampleType.details(list[0].id)
+        details = details.update({ id: list[0].id, name: list[0].name })
+
+        render json: {
+          sample_types: list,
+          first: details
+         }.to_json, status: :ok
+      end
+
+      # DETAILS FOR SELECTED SAMPLE TYPE
+      def show
+        # CHECK FOR ADMIN PERMISSIONS
+        status, response = check_token_for_permission(1)
+        render json: response.to_json, status: status.to_sym and return if response[:error]
+
+        id = Input.number(params[:id])
+
+        # GET ITEM
+        sample_type = SampleType.find_id(id)
+        render json: { sample_type: nil  }.to_json, status: :ok and return if !sample_type
+
+        # GET DETAILS OF FIRST ITEM IN LIST
+        details = SampleType.details(id)
+        details = details.update({ id: id, name: sample_type.name, description: sample_type.description })
+
+        render json: {
+          sample_type: details
+         }.to_json, status: :ok
+      end
+
+      # CREATE NEW SAMPLE TYPE
+      def create
+        # CHECK FOR ADMIN PERMISSIONS
+        status, response = check_token_for_permission(1)
+        render json: response.to_json, status: status.to_sym and return if response[:error]
+
+        sample_type, errors = SampleType.create(params)
+        render json: { errors: errors }.to_json, status: :ok and return if !sample_type
+
+        render json: sample_type.to_json, status: :created
+
+      end
+
+      # UPDATE SAMPLE TYPE
+      def update
+         # CHECK FOR ADMIN PERMISSIONS
+        status, response = check_token_for_permission(1)
+        render json: response.to_json, status: status.to_sym and return if response[:error]
+
+        id = Input.number(params[:id])
+
+        # GET ITEM
+        sample_type = SampleType.find_id(id)
+        render json: { sample_type: nil  }.to_json, status: :ok and return if !sample_type
+
+        # UPDATE SAMPLE
+        # NOTE: ANY ERRORS HANDLED AUTOMATICALLY AND SILENTLY
+        sample_type = sample_type.update(params)
+
+        render json: sample_type.to_json, status: :ok
+      end
+
+      # DELETE SAMPLE TYPE
+      def delete
+        # CHECK FOR ADMIN PERMISSIONS
+        status, response = check_token_for_permission(1)
+        render json: response.to_json, status: status.to_sym and return if response[:error]
+
+        id = Input.number(params[:id])
+
+        # GET ITEM
+        sample = SampleType.find_id(id)
+        render json: { sample_type: nil  }.to_json, status: :ok and return if !sample
+
+        # DELETE ITEM AND RELATED ITEMS WITHOUT FOREIGN KEYS
+        sample.delete_sample_type
+
+        render json: {
+          message: "deleted"
+         }.to_json, status: :ok
+
+      end
+
+    end
+  end
+end

--- a/backend/app/controllers/api/v3/sample_types_controller.rb
+++ b/backend/app/controllers/api/v3/sample_types_controller.rb
@@ -30,14 +30,14 @@ module Api
       # Return details for a specific sample type.
       #
       # @param token [String] a token
-      # @param id [id] the id of the sample type
+      # @param id [Int] the id of the sample type
       # @return the sample type
       def show
         # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        id = Input.index(params[:id])
+        id = Input.int(params[:id])
 
         # Get sample type
         sample_type = SampleType.find_id(id)
@@ -55,9 +55,9 @@ module Api
       # Create a new sample type.
       #
       # @param token [String] a token
-      # @param name [name] the name of the sample type
-      # @param description [description] the description of the sample type
-      # @param field_types [hash] the :field_types to be used for the allowable_field_types
+      # @param name [String] the name of the sample type
+      # @param description [String] the description of the sample type
+      # @param field_types [Hash] the :field_types to be used for the allowable_field_types
       # @return the sample type
       def create
         # Check for admin permissions
@@ -69,23 +69,22 @@ module Api
         render json: { errors: errors }.to_json, status: :ok and return if !sample_type
 
         render json: sample_type.to_json, status: :created
-
       end
 
       # Update a sample type.
       #
       # @param token [String] a token
       # @param id [Int] the id of the sample type
-      # @param name [name] the name of the sample type
-      # @param description [description] the description of the sample type
-      # @param field_types [hash] the :field_types to be used for the allowable_field_types
+      # @param name [String] the name of the sample type
+      # @param description [String] the description of the sample type
+      # @param field_types [Hash] the :field_types to be used for the allowable_field_types
       # @return the sample type
       def update
          # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        id = Input.index(params[:id])
+        id = Input.int(params[:id])
 
         # Get sample type
         sample_type = SampleType.find_id(id)
@@ -108,7 +107,7 @@ module Api
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        id = Input.index(params[:id])
+        id = Input.int(params[:id])
 
         # Get sample type
         sample = SampleType.find_id(id)

--- a/backend/app/controllers/api/v3/sample_types_controller.rb
+++ b/backend/app/controllers/api/v3/sample_types_controller.rb
@@ -55,17 +55,18 @@ module Api
       # Create a new sample type.
       #
       # @param token [String] a token
-      # @param name [String] the name of the sample type
-      # @param description [String] the description of the sample type
-      # @param field_types [Hash] the :field_types to be used for the allowable_field_types
+      # @param sample_type [Hash] the sample_type
       # @return the sample type
       def create
         # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        # create sample type
-        sample_type, errors = SampleType.create(params)
+        # Read sample type parameter
+        params_sample_type = params[:sample_type] || {}
+
+        # Create sample type
+        sample_type, errors = SampleType.create(params_sample_type)
         render json: { errors: errors }.to_json, status: :ok and return if !sample_type
 
         render json: sample_type.to_json, status: :created
@@ -74,25 +75,24 @@ module Api
       # Update a sample type.
       #
       # @param token [String] a token
-      # @param id [Int] the id of the sample type
-      # @param name [String] the name of the sample type
-      # @param description [String] the description of the sample type
-      # @param field_types [Hash] the :field_types to be used for the allowable_field_types
+      # @param sample_type [Hash] the sample_type
       # @return the sample type
       def update
-         # Check for admin permissions
+        # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
-        id = Input.int(params[:id])
+        # Read sample type parameter
+        params_sample_type = params[:sample_type] || {}
 
         # Get sample type
+        id = Input.int(params[:id])
         sample_type = SampleType.find_id(id)
         render json: { sample_type: nil }.to_json, status: :ok and return if !sample_type
 
         # Update sample type
         # Note: any errors handled automatically and silently
-        sample_type = sample_type.update(params)
+        sample_type = sample_type.update(params_sample_type)
 
         render json: sample_type.to_json, status: :ok
       end

--- a/backend/app/controllers/api/v3/sample_types_controller.rb
+++ b/backend/app/controllers/api/v3/sample_types_controller.rb
@@ -4,10 +4,10 @@ module Api
   module V3
     # Sample type api calls
     class SampleTypesController < ApplicationController
-      # Return all sample types.
+      # Return all sample types plus details for the first sample type
       #
       # @param token [String] a token
-      # @return all sample types
+      # @return all sample types plus details for the first sample type
       def index
         # Check for admin permissions
         status, response = check_token_for_permission(1)
@@ -17,7 +17,7 @@ module Api
         list = SampleType.find_all
         render json: { sample_types: nil,  }.to_json, status: :ok and return if list.length == 0
 
-        # Get details of first item in list
+        # Get details of first sample type in list
         details = SampleType.details(list[0].id)
         details = details.update({ id: list[0].id, name: list[0].name })
 
@@ -39,17 +39,17 @@ module Api
 
         id = Input.number(params[:id])
 
-        # Get item
+        # Get sample type
         sample_type = SampleType.find_id(id)
         render json: { sample_type: nil  }.to_json, status: :ok and return if !sample_type
 
-        # Get details of first item in list
+        # Get details for sample type
         details = SampleType.details(id)
         details = details.update({ id: id, name: sample_type.name, description: sample_type.description })
 
         render json: {
           sample_type: details
-         }.to_json, status: :ok
+        }.to_json, status: :ok
       end
 
       # Create a new sample type.
@@ -64,6 +64,7 @@ module Api
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
+        # create sample type
         sample_type, errors = SampleType.create(params)
         render json: { errors: errors }.to_json, status: :ok and return if !sample_type
 
@@ -86,11 +87,11 @@ module Api
 
         id = Input.number(params[:id])
 
-        # Get item
+        # Get sample type
         sample_type = SampleType.find_id(id)
         render json: { sample_type: nil  }.to_json, status: :ok and return if !sample_type
 
-        # Update sample
+        # Update sample type
         # Note: any errors handled automatically and silently
         sample_type = sample_type.update(params)
 
@@ -109,17 +110,16 @@ module Api
 
         id = Input.number(params[:id])
 
-        # Get item
+        # Get sample type
         sample = SampleType.find_id(id)
         render json: { sample_type: nil  }.to_json, status: :ok and return if !sample
 
-        # Delete item and related items without foreign keys
+        # Delete sample type and related items that do not have foreign keys
         sample.delete_sample_type
 
         render json: {
           message: "deleted"
          }.to_json, status: :ok
-
       end
 
     end

--- a/backend/app/controllers/api/v3/sample_types_controller.rb
+++ b/backend/app/controllers/api/v3/sample_types_controller.rb
@@ -7,7 +7,6 @@ module Api
       # Return all sample types.
       #
       # @param token [String] a token
-      #
       # @return all sample types
       def index
         # Check for admin permissions
@@ -32,7 +31,6 @@ module Api
       #
       # @param token [String] a token
       # @param id [id] the id of the sample type
-      #
       # @return the sample type
       def show
         # Check for admin permissions
@@ -60,7 +58,6 @@ module Api
       # @param name [name] the name of the sample type
       # @param description [description] the description of the sample type
       # @param field_types [hash] the :field_types to be used for the allowable_field_types
-      #
       # @return the sample type
       def create
         # Check for admin permissions
@@ -81,7 +78,6 @@ module Api
       # @param name [name] the name of the sample type
       # @param description [description] the description of the sample type
       # @param field_types [hash] the :field_types to be used for the allowable_field_types
-      #
       # @return the sample type
       def update
          # Check for admin permissions
@@ -105,7 +101,6 @@ module Api
       #
       # @param token [String] a token
       # @param id [Int] the id of the sample type
-      #
       # @return a success message
       def delete
         # Check for admin permissions

--- a/backend/app/controllers/api/v3/token_controller.rb
+++ b/backend/app/controllers/api/v3/token_controller.rb
@@ -11,14 +11,14 @@ module Api
         password = params[:password]
 
         user = User.find_by(login: login)
-        render json: { error: 'Invalid.' }.to_json, status: :unauthorized and return if !user || !user.authenticate(password)
+        render json: { error: 'Invalid' }.to_json, status: :unauthorized and return if !user || !user.authenticate(password)
 
         ip = request.remote_ip
         timenow = Time.now.utc
 
         # CREATE A TOKEN
         token = UserToken.new_token(ip)
-        render json: { error: 'Invalid.' }.to_json, status: :unauthorized unless token
+        render json: { error: 'Invalid' }.to_json, status: :unauthorized unless token
 
         user_token = UserToken.new
         user_token.user_id = user.id
@@ -38,9 +38,9 @@ module Api
         all = (params[:all] == 'true' || params[:all] == 'on')
 
         signout = User.sign_out({ ip: ip, token: token, all: all })
-        render json: { error: 'Invalid.' }.to_json, status: :unauthorized and return unless signout
+        render json: { error: 'Invalid' }.to_json, status: :unauthorized and return unless signout
 
-        render json: { message: 'Signed out.' }.to_json, status: :ok
+        render json: { message: 'Signed out' }.to_json, status: :ok
       end
 
       # GET USER

--- a/backend/app/controllers/api/v3/token_controller.rb
+++ b/backend/app/controllers/api/v3/token_controller.rb
@@ -2,10 +2,14 @@
 
 module Api
   module V3
-    # TOKEN RELATED API CALLS
+    # Token related api calls
     class TokenController < ApplicationController
-      # SIGN IN
-      # /api/v3/token/create?login=<login>&password=<password>
+      # Creates a token.
+      #
+      # @param login [String] login
+      # @param password [String] password
+      #
+      # @return a token
       def create
         login = params[:login].to_s.strip.downcase
         password = params[:password]
@@ -16,7 +20,7 @@ module Api
         ip = request.remote_ip
         timenow = Time.now.utc
 
-        # CREATE A TOKEN
+        # Create a token
         token = UserToken.new_token(ip)
         render json: { error: 'Invalid' }.to_json, status: :unauthorized unless token
 
@@ -30,8 +34,12 @@ module Api
         render json: { token: token }.to_json, status: :ok
       end
 
-      # SIGN OUT (ALL = SIGN OUT OF ALL DEVICES)
-      # /api/v3/token/delete?token=<token>&all=<true>
+      # Removes a token or optionally all tokens associated with this user.
+      #
+      # @param token [String] a token
+      # @param all [String] "true" or "on" to remove all tokens associated with this user
+      #
+      # @return a success message
       def delete
         ip = request.remote_ip
         token = params[:token].to_s.strip.downcase
@@ -43,11 +51,16 @@ module Api
         render json: { message: 'Signed out' }.to_json, status: :ok
       end
 
-      # GET USER
-      # /api/v3/token/get_user?token=<token>
+      # Returns the user for the token and an optional permission_id.
+      #
+      # @param token [String] a token
+      # @param permission_id [Int] the optional permission_id to check
+      #
+      # @return the user
       def get_user
         permission_id = params[:permission_id] ? params[:permission_id].to_i : 0
 
+        # Check for permission_id permissions
         status, response = check_token_for_permission(permission_id)
         render json: response.to_json, status: status.to_sym
       end

--- a/backend/app/controllers/api/v3/token_controller.rb
+++ b/backend/app/controllers/api/v3/token_controller.rb
@@ -8,7 +8,6 @@ module Api
       #
       # @param login [String] login
       # @param password [String] password
-      #
       # @return a token
       def create
         login = params[:login].to_s.strip.downcase
@@ -38,7 +37,6 @@ module Api
       #
       # @param token [String] a token
       # @param all [String] "true" or "on" to remove all tokens associated with this user
-      #
       # @return a success message
       def delete
         ip = request.remote_ip
@@ -55,7 +53,6 @@ module Api
       #
       # @param token [String] a token
       # @param permission_id [Int] the optional permission_id to check
-      #
       # @return the user
       def get_user
         permission_id = params[:permission_id] ? params[:permission_id].to_i : 0

--- a/backend/app/controllers/api/v3/token_controller.rb
+++ b/backend/app/controllers/api/v3/token_controller.rb
@@ -11,14 +11,14 @@ module Api
         password = params[:password]
 
         user = User.find_by(login: login)
-        render json: { error: 'Invalid' }.to_json, status: :unauthorized and return if !user || !user.authenticate(password)
+        render json: { error: 'Invalid.' }.to_json, status: :unauthorized and return if !user || !user.authenticate(password)
 
         ip = request.remote_ip
         timenow = Time.now.utc
 
         # CREATE A TOKEN
         token = UserToken.new_token(ip)
-        render json: { error: 'Invalid' }.to_json, status: :unauthorized unless token
+        render json: { error: 'Invalid.' }.to_json, status: :unauthorized unless token
 
         user_token = UserToken.new
         user_token.user_id = user.id
@@ -38,9 +38,9 @@ module Api
         all = (params[:all] == 'true' || params[:all] == 'on')
 
         signout = User.sign_out({ ip: ip, token: token, all: all })
-        render json: { error: 'Invalid' }.to_json, status: :unauthorized and return unless signout
+        render json: { error: 'Invalid.' }.to_json, status: :unauthorized and return unless signout
 
-        render json: { message: 'Signed out' }.to_json, status: :ok
+        render json: { message: 'Signed out.' }.to_json, status: :ok
       end
 
       # GET USER

--- a/backend/app/controllers/api/v3/users_controller.rb
+++ b/backend/app/controllers/api/v3/users_controller.rb
@@ -5,7 +5,10 @@ module Api
     # USER RELATED API CALLS
     class UsersController < ApplicationController
       # RETURN LIST OF USERS FILTERED AND/OR SORTED BY PERMISSION
-      # /api/v3/users/permissions?token=<token>&show[]=[1,2,3,4,5,6]&sort=<sort>
+      # /api/v3/users/permissions
+      #   token=<token>
+      #   show[]=[<permission_ids>]
+      #   sort=<sort>
       def permissions
         # CHECK FOR ADMIN PERMISSIONS
         status, response = check_token_for_permission(1)
@@ -36,8 +39,12 @@ module Api
       end
 
       # SET SPECIFIC PERMISSION FOR SPECIFIC USER
-      # /api/v3/users/set_permission?token=<token>&user_id=<user_id>&permission_id=<permission_id>&value=<true>
-      def set_permission
+      # /api/v3/users/permissions/update
+      #   token=<token>
+      #   user_id=<user_id>
+      #   permission_id=<permission_id>
+      #   value=<true>
+      def permissions_update
         # CHECK FOR ADMIN PERMISSIONS
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
@@ -50,7 +57,7 @@ module Api
         end
 
         valid = User.set_permission(uid, rid, val)
-        render json: { error: 'Invalid' }.to_json, status: :unauthorized and return unless valid
+        render json: { error: 'Invalid.' }.to_json, status: :unauthorized and return unless valid
 
         render json: { user: { id: valid.id, name: valid.name, login: valid.login, permission_ids: valid.permission_ids } }.to_json, status: :ok
       end

--- a/backend/app/controllers/api/v3/users_controller.rb
+++ b/backend/app/controllers/api/v3/users_controller.rb
@@ -2,15 +2,17 @@
 
 module Api
   module V3
-    # USER RELATED API CALLS
+    # User related api calls
     class UsersController < ApplicationController
-      # RETURN LIST OF USERS FILTERED AND/OR SORTED BY PERMISSION
-      # /api/v3/users/permissions
-      #   token=<token>
-      #   show[]=[<permission_ids>]
-      #   sort=<sort>
+      # Returns a filtered / sorted list of users based on permission_ids.
+      #
+      # @param token [String] a token
+      # @param show [Array] the list of permission ids to filter
+      # @param sort [String] the sort order
+      #
+      # @return a filtered / sorted list of users
       def permissions
-        # CHECK FOR ADMIN PERMISSIONS
+        # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
@@ -38,14 +40,16 @@ module Api
         render json: { users: users }.to_json, status: :ok
       end
 
-      # SET SPECIFIC PERMISSION FOR SPECIFIC USER
-      # /api/v3/users/permissions/update
-      #   token=<token>
-      #   user_id=<user_id>
-      #   permission_id=<permission_id>
-      #   value=<true>
+      # Set a specific permission for a specific user.
+      #
+      # @param token [String] a token
+      # @param user_id [Int] the id of the user to change
+      # @param permission_id [Int] the id of the permission to change
+      # @param value [String] "true" or "on" to turn the permission on, anything else to turn the permission off
+      #
+      # @return the user
       def permissions_update
-        # CHECK FOR ADMIN PERMISSIONS
+        # Check for admin permissions
         status, response = check_token_for_permission(1)
         render json: response.to_json, status: status.to_sym and return if response[:error]
 

--- a/backend/app/controllers/api/v3/users_controller.rb
+++ b/backend/app/controllers/api/v3/users_controller.rb
@@ -57,7 +57,7 @@ module Api
         end
 
         valid = User.set_permission(uid, rid, val)
-        render json: { error: 'Invalid.' }.to_json, status: :unauthorized and return unless valid
+        render json: { error: 'Invalid' }.to_json, status: :unauthorized and return unless valid
 
         render json: { user: { id: valid.id, name: valid.name, login: valid.login, permission_ids: valid.permission_ids } }.to_json, status: :ok
       end

--- a/backend/app/controllers/api/v3/users_controller.rb
+++ b/backend/app/controllers/api/v3/users_controller.rb
@@ -9,7 +9,6 @@ module Api
       # @param token [String] a token
       # @param show [Array] the list of permission ids to filter
       # @param sort [String] the sort order
-      #
       # @return a filtered / sorted list of users
       def permissions
         # Check for admin permissions
@@ -46,7 +45,6 @@ module Api
       # @param user_id [Int] the id of the user to change
       # @param permission_id [Int] the id of the permission to change
       # @param value [String] "true" or "on" to turn the permission on, anything else to turn the permission off
-      #
       # @return the user
       def permissions_update
         # Check for admin permissions

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::API
     when 403
       status = "forbidden"
       permission = Permission.permission_ids[permission_id]
-      error = permission ? "#{permission.capitalize} permissions required." : 'Forbidden.'
+      error = permission ? "#{permission.capitalize} permissions required" : 'Forbidden'
       response = { error: error }
     when 200
       status = "ok"

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,13 +1,29 @@
 # frozen_string_literal: true
+require 'input'
 
 # APPLICATION CONTROLLER
 class ApplicationController < ActionController::API
   # CHECK THE TOKEN AGAINST SPECIFIC PERMISSION_ID (0 = ANYTHING NOT RETIRED)
   # RETURN STATUS <AND> ( ERROR <OR> USER )
   def check_token_for_permission(permission_id = 0)
-    ip = request.remote_ip.to_s
+    ip = request.remote_ip
     token = params[:token].to_s.strip.downcase
 
-    User.validate_token(ip: ip, token: token, check_permission_id: permission_id)
+    status_code, datum = User.validate_token({ ip: ip, token: token }, permission_id)
+    case status_code
+    when 401
+      status = "unauthorized"
+      response = { error: datum }
+    when 403
+      status = "forbidden"
+      permission = Permission.permission_ids[permission_id]
+      error = permission ? "#{permission.capitalize} permissions required." : 'Forbidden.'
+      response = { error: error }
+    when 200
+      status = "ok"
+      response = { user: datum }
+    end
+    return status, response
   end
+
 end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 require 'input'
 
-# APPLICATION CONTROLLER
+# application_controller
 class ApplicationController < ActionController::API
-  # CHECK THE TOKEN AGAINST SPECIFIC PERMISSION_ID (0 = ANYTHING NOT RETIRED)
-  # RETURN STATUS <AND> ( ERROR <OR> USER )
+  # Check whether a token has a specific permission_id (0 = anything that is not retired).
+  #
+  # @param token [String] a token
+  # @param permission_id [Int] the specific permission_id to check
+  #
+  # @return the the status (i.e., ok, unauthorized, forbidden) and either the user or an error
   def check_token_for_permission(permission_id = 0)
     ip = request.remote_ip
     token = params[:token].to_s.strip.downcase

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -7,7 +7,6 @@ class ApplicationController < ActionController::API
   #
   # @param token [String] a token
   # @param permission_id [Int] the specific permission_id to check
-  #
   # @return the the status (i.e., ok, unauthorized, forbidden) and either the user or an error
   def check_token_for_permission(permission_id = 0)
     ip = request.remote_ip

--- a/backend/app/models/allowable_field_type.rb
+++ b/backend/app/models/allowable_field_type.rb
@@ -1,0 +1,4 @@
+# SAMPLE_TYPES TABLE
+class AllowableFieldType < ActiveRecord::Base
+
+end

--- a/backend/app/models/allowable_field_type.rb
+++ b/backend/app/models/allowable_field_type.rb
@@ -8,7 +8,7 @@ class AllowableFieldType < ActiveRecord::Base
   # @option allowable_field_type[:sample_type_id] [Int] the id of the (allowable) sample type
   # @return true
   def self.create(field_type_id, allowable_field_type)
-    sample_type_id = Input.index(allowable_field_type[:sample_type_id])
+    sample_type_id = Input.int(allowable_field_type[:sample_type_id])
     sql = "select * from sample_types where id = #{sample_type_id} limit 1"
 
     if (SampleType.find_by_sql sql)[0]
@@ -31,12 +31,12 @@ class AllowableFieldType < ActiveRecord::Base
   # @return id or 0
   def self.update(field_type_id, allowable_field_type)
     # Verify that the sample_type_id is valid
-    sample_type_id = Input.index(allowable_field_type[:sample_type_id])
+    sample_type_id = Input.int(allowable_field_type[:sample_type_id])
     sql = "select * from sample_types where id = #{sample_type_id} limit 1"
     return 0 if !(SampleType.find_by_sql sql)[0]
 
     # Find existing allowable_field_type or create new one
-    allowable_field_type_id = Input.index(allowable_field_type[:id])
+    allowable_field_type_id = Input.int(allowable_field_type[:id])
     sql = "select * from allowable_field_types where id = #{allowable_field_type_id} and field_type_id = #{field_type_id} limit 1"
     allowable_field_type_update = (AllowableFieldType.find_by_sql sql)[0] || AllowableFieldType.new
 

--- a/backend/app/models/allowable_field_type.rb
+++ b/backend/app/models/allowable_field_type.rb
@@ -1,4 +1,51 @@
 # allowable_field_types table
 class AllowableFieldType < ActiveRecord::Base
 
+  # Create an allowable field type
+  #
+  # @param field_type_id [Int] id of the field type
+  # @param allowable_field_type [Hash] the allowable field type
+  # @option allowable_field_type[:sample_type_id] [Int] the id of the (allowable) sample type
+  # @return true
+  def self.create(field_type_id, allowable_field_type)
+    sample_type_id = Input.index(allowable_field_type[:sample_type_id])
+    sql = "select * from sample_types where id = #{sample_type_id} limit 1"
+
+    if (SampleType.find_by_sql sql)[0]
+      allowable_field_type_new  = AllowableFieldType.new(
+        field_type_id: field_type_id,
+        sample_type_id: sample_type_id
+      )
+      allowable_field_type_new.save
+    end
+
+    return true
+  end
+
+  # Update an allowable field type
+  #
+  # @param field_type_id [Int] id of the field type
+  # @param allowable_field_type [Hash] the allowable field type
+  # @option allowable_field_type[:id] [Int] the id of the allowable field type
+  # @option allowable_field_type[:sample_type_id] [Int] the id of the sample type
+  # @return id or 0
+  def self.update(field_type_id, allowable_field_type)
+    # Verify that the sample_type_id is valid
+    sample_type_id = Input.index(allowable_field_type[:sample_type_id])
+    sql = "select * from sample_types where id = #{sample_type_id} limit 1"
+    return 0 if !(SampleType.find_by_sql sql)[0]
+
+    # Find existing allowable_field_type or create new one
+    allowable_field_type_id = Input.index(allowable_field_type[:id])
+    sql = "select * from allowable_field_types where id = #{allowable_field_type_id} and field_type_id = #{field_type_id} limit 1"
+    allowable_field_type_update = (AllowableFieldType.find_by_sql sql)[0] || AllowableFieldType.new
+
+    # Create / update the allowable_field_type
+    allowable_field_type_update.field_type_id  = field_type_id
+    allowable_field_type_update.sample_type_id = sample_type_id
+    allowable_field_type_update.save
+
+    # Return the id
+    return allowable_field_type_update.id
+  end
 end

--- a/backend/app/models/allowable_field_type.rb
+++ b/backend/app/models/allowable_field_type.rb
@@ -1,4 +1,4 @@
-# SAMPLE_TYPES TABLE
+# allowable_field_types table
 class AllowableFieldType < ActiveRecord::Base
 
 end

--- a/backend/app/models/application_record.rb
+++ b/backend/app/models/application_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# APPLICATION RECORD
+# application_record base
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/backend/app/models/field_type.rb
+++ b/backend/app/models/field_type.rb
@@ -58,7 +58,7 @@ class FieldType < ActiveRecord::Base
     allowable_field_type_ids = [0]
 
     # Find existing feild_type or create new one
-    fid = Input.index(field_type[:id])
+    fid = Input.int(field_type[:id])
     sql = "select * from field_types where id = #{fid} and parent_id = #{parent_id} limit 1"
     field_type_update = (FieldType.find_by_sql sql)[0] || FieldType.new
 

--- a/backend/app/models/field_type.rb
+++ b/backend/app/models/field_type.rb
@@ -1,0 +1,4 @@
+# SAMPLE_TYPES TABLE
+class FieldType < ActiveRecord::Base
+
+end

--- a/backend/app/models/field_type.rb
+++ b/backend/app/models/field_type.rb
@@ -1,4 +1,103 @@
 # field_types table
 class FieldType < ActiveRecord::Base
 
+  # Create a field type
+  #
+  # @param field_type [Hash] the field type
+  # @option field_type[:name] [String] name
+  # @option field_type[:ftype] [String]  ftype
+  # @option field_type[:required] [String] required - interpreted as Boolen
+  # @option field_type[:array] [String] array - interpreted as Boolean
+  # @option field_type[:choices] [String] choices
+  # @option field_type[:allowable_field_types] [Array] array of allowable field types (for ftype = "sample")
+  # @return true
+  def self.create_sampletype(parent_id, field_type)
+    # Read the parameters
+    fname     = Input.text(field_type[:name])
+    ftype     = Input.text(field_type[:ftype])
+    frequired = Input.boolean(field_type[:required]) ? 1 : nil
+    farray    = Input.boolean(field_type[:array]) ? 1 : nil
+    fchoices  = Input.text(field_type[:choices])
+
+    field_type_new  = FieldType.new(
+      parent_id: parent_id,
+      name: fname,
+      ftype: ftype,
+      choices: fchoices,
+      array: farray,
+      required: frequired,
+      parent_class: "SampleType"
+    )
+    field_type_new.save
+
+    # Save allowable field types if the field type is "sample"
+    if ftype == "sample" and field_type[:allowable_field_types].kind_of?(Array)
+      field_type[:allowable_field_types].each do |aft|
+        AllowableFieldType.create(field_type_new.id, aft)
+      end
+    end
+
+    return true
+  end
+
+  # Update or create a new field type (if the id does not exist)
+  #
+  # @param feild_type = [Hash] field type
+  # @option feild_type[:id] id [Int] the id of the existing field type
+  # @option feild_type[:name] [String] name
+  # @option feild_type[:ftype] [String]  ftype
+  # @option feild_type[:required] [String] required - interpreted as Boolean
+  # @option feild_type[:array] [String] array - interpreted as Boolean
+  # @option feild_type[:choices] [String] choices
+  # @option feild_type[:allowable_field_types] [Array] array of allowable field types (for ftype = "sample")
+  # @return the id of the field type or 0 (if the id does not exist and the name is blank)
+  def self.update_sampletype(parent_id, field_type)
+    # List of allowable field type ids for this field_type_id
+    # - Used to delete allowable field types that were removed on update
+    # - Initialize with id = 0 to generate the appropriate sql query later
+    allowable_field_type_ids = [0]
+
+    # Find existing feild_type or create new one
+    fid = Input.index(field_type[:id])
+    sql = "select * from field_types where id = #{fid} and parent_id = #{parent_id} limit 1"
+    field_type_update = (FieldType.find_by_sql sql)[0] || FieldType.new
+
+    # Reset fname if it is blank and the id exists
+    fname = Input.text(field_type[:name])
+    fname = fname || field_type_update.name
+    return 0 if fname == ""
+
+    # Save the field_type
+    ftype     = Input.text(field_type[:ftype])
+    frequired = Input.boolean(field_type[:required]) ? 1 : nil
+    farray    = Input.boolean(field_type[:array]) ? 1 : nil
+    fchoices  = Input.text(field_type[:choices])
+
+    field_type_update.parent_id    = parent_id
+    field_type_update.name         = fname
+    field_type_update.ftype        = ftype
+    field_type_update.required     = frequired
+    field_type_update.array        = farray
+    field_type_update.choices      = fchoices
+    field_type_update.parent_class = "SampleType"
+    field_type_update.save
+
+    # Set the id
+    field_type_id = field_type_update.id
+
+    # Save allowable field types if the field type is "sample"
+    if ftype == "sample" and field_type[:allowable_field_types].kind_of?(Array)
+      field_type[:allowable_field_types].each do |allowable_field_type|
+        # Update the allowable field type and append the id to list of allowable_field_type_ids
+        allowable_field_type_ids << AllowableFieldType.update(field_type_id, allowable_field_type)
+      end
+    end
+
+    # Remove allowable_field_types for this field type that are no loner defined
+    sql = "delete from allowable_field_types where field_type_id = #{field_type_id} and id not in (#{allowable_field_type_ids.join(",")})"
+    AllowableFieldType.connection.execute sql
+
+    return field_type_update.id
+  end
+
 end

--- a/backend/app/models/field_type.rb
+++ b/backend/app/models/field_type.rb
@@ -1,4 +1,4 @@
-# SAMPLE_TYPES TABLE
+# field_types table
 class FieldType < ActiveRecord::Base
 
 end

--- a/backend/app/models/field_type.rb
+++ b/backend/app/models/field_type.rb
@@ -94,6 +94,7 @@ class FieldType < ActiveRecord::Base
     end
 
     # Remove allowable_field_types for this field type that are no loner defined
+    # NOTE: Could move this to allowable_field_type.rb but left it here because it is custom to the update
     sql = "delete from allowable_field_types where field_type_id = #{field_type_id} and id not in (#{allowable_field_type_ids.join(",")})"
     AllowableFieldType.connection.execute sql
 

--- a/backend/app/models/object_type.rb
+++ b/backend/app/models/object_type.rb
@@ -1,4 +1,4 @@
-# SAMPLE_TYPES TABLE
+# object_types table
 class ObjectType < ActiveRecord::Base
 
 end

--- a/backend/app/models/object_type.rb
+++ b/backend/app/models/object_type.rb
@@ -1,0 +1,4 @@
+# SAMPLE_TYPES TABLE
+class ObjectType < ActiveRecord::Base
+
+end

--- a/backend/app/models/permission.rb
+++ b/backend/app/models/permission.rb
@@ -1,22 +1,25 @@
 # frozen_string_literal: true
 
-# DEFAULT PERMISSIONS
-#   1 - ADMIN
-#   2 - MANAGE
-#   3 - RUN
-#   4 - DESIGN
-#   5 - DEVELOP
-#   6 - RETIRED
+# Default permissions
+#   1 - admin
+#   2 - manage
+#   3 - run
+#   4 - design
+#   5 - develop
+#   6 - retired
 
-# RETIRED AND ADMIN ARE SPECIAL CASES
-#   - IF RETIRED, THEN THE USER HAS NO ACCESS AND ALL OTHER PERMISSIONS ARE IGNORED (INCLUDING ADMIN)
-#   - IF ADMIN (AND NOT RETIRED), THEN THE USER HAS ACCESS TO MANAGE, RUN, DESIGN, AND DEVELOP
-#     REGARDLESS OF WHETHER THE USER HAS EXPLICIT PERMISSIONS FOR THOSE ITEMS
+# Retired and admin are special cases
+#   - If retired, then the user has no access and all other permissions are ignored (including admin)
+#   - If admin (and not retired), then the user has access to manage, run, design, and develop
+#     Regardless of whether the user has explicit permissions for those items
 
-# PERMISSIONS TABLE
+# permissions table
 class Permission < ActiveRecord::Base
-  # usage   permission_ids[<id>]
-  # usage   permission_ids.key(<name>)
+  # Cache and return the list of permissions.
+  #
+  # @param clear_cache [Boolean] true to clear the cache
+  #
+  # @return permissions
   def self.permission_ids(clear_cache = false)
     Rails.cache.delete 'permission_ids' if clear_cache
     Rails.cache.fetch 'permission_ids' do

--- a/backend/app/models/permission.rb
+++ b/backend/app/models/permission.rb
@@ -18,7 +18,6 @@ class Permission < ActiveRecord::Base
   # Cache and return the list of permissions.
   #
   # @param clear_cache [Boolean] true to clear the cache
-  #
   # @return permissions
   def self.permission_ids(clear_cache = false)
     Rails.cache.delete 'permission_ids' if clear_cache

--- a/backend/app/models/sample_type.rb
+++ b/backend/app/models/sample_type.rb
@@ -65,10 +65,10 @@ class SampleType < ActiveRecord::Base
 
   # Create a sample types.
   #
-  # @param st [Hash] the sample type
-  # @option st[:name] [String] the name of the sample type
-  # @option st[:description] [String] the description of the sample type
-  # @option st[:field_types] [Hash] the field_type attributes associated with the sample type
+  # @param sample_type [Hash] the sample type
+  # @option sample_type[:name] [String] the name of the sample type
+  # @option sample_type[:description] [String] the description of the sample type
+  # @option sample_type[:field_types] [Hash] the field_type attributes associated with the sample type
   # @return the sample type
   def self.create(sample_type)
     name = Input.text(sample_type[:name])
@@ -103,11 +103,11 @@ class SampleType < ActiveRecord::Base
   # - Also updates allowable field types for each field type
   # - Any potential errors are handled automatically and silently
   #
-  # @param st [Hash] the sample type
-  # @option st[:id] [Int] the id of the sample type
-  # @option st[:name] [String] the name of the sample type
-  # @option st[:description] [String] the description of the sample type
-  # @option st[:field_types] [Hash] the field_type attributes associated with the sample type
+  # @param sample_type [Hash] the sample type
+  # @option sample_type[:id] [Int] the id of the sample type
+  # @option sample_type[:name] [String] the name of the sample type
+  # @option sample_type[:description] [String] the description of the sample type
+  # @option sample_type[:field_types] [Hash] the field_type attributes associated with the sample type
   # @return the sample type
   def update(sample_type)
     input_name = Input.text(sample_type[:name])

--- a/backend/app/models/sample_type.rb
+++ b/backend/app/models/sample_type.rb
@@ -69,11 +69,9 @@ class SampleType < ActiveRecord::Base
   # Create a sample types.
   #
   # @param st [Hash] the sample type
-  #
   # @option st[:name] [String] the name of the sample type
   # @option st[:description] [String] the description of the sample type
   # @option st[:field_types] [Hash] the field_type attributes associated with the sample type
-  #
   # feild_types = {
   #   name [String] name
   #   ftype [String]  ftype
@@ -82,11 +80,9 @@ class SampleType < ActiveRecord::Base
   #   choices [String] choices
   #   allowable_field_types [Array] array of allowable field types (for ftype = "sample")
   # }
-  #
   # allowable_field_type = {
   #   sample_type_id [Int] id of the allowable field type
   # }
-  #
   # @return the sample type
   def self.create(st)
     name = Input.text(st[:name])
@@ -108,33 +104,33 @@ class SampleType < ActiveRecord::Base
       st[:field_types].each do |ft|
         fname     = Input.text(ft[:name])
         ftype     = Input.text(ft[:ftype])
-        frequired = Input.boolean(ft[:required])
-        farray    = Input.boolean(ft[:array])
+        frequired = Input.boolean(ft[:required]) ? 1 : nil
+        farray    = Input.boolean(ft[:array]) ? 1 : nil
         fchoices  = Input.text(ft[:choices])
 
         if fname != ""
-          field_type_new  = FieldType.new
-
-          field_type_new.parent_id    = sample_type_new.id
-          field_type_new.name         = fname
-          field_type_new.ftype        = ftype
-          field_type_new.choices      = fchoices
-          field_type_new.array        = farray
-          field_type_new.required     = frequired
-          field_type_new.parent_class = "SampleType"
+          field_type_new  = FieldType.new(
+            parent_id: sample_type_new.id,
+            name: fname,
+            ftype: ftype,
+            choices: fchoices,
+            array: farray,
+            required: frequired,
+            parent_class: "SampleType"
+          )
           field_type_new.save
 
-          # SAVE ALLOWABLE FIELD TYPES IF THE FIELD TYPE IS "SAMPLE"
+          # Save allowable field types if the field type is "sample"
           if ftype == "sample" and ft[:allowable_field_types].kind_of?(Array)
             ft[:allowable_field_types].each do |aft|
               sample_type_id = Input.number(aft[:sample_type_id])
               sql = "select * from sample_types where id = #{sample_type_id} limit 1"
 
               if (SampleType.find_by_sql sql)[0]
-                allowable_field_type_new  = AllowableFieldType.new
-
-                allowable_field_type_new.field_type_id  = field_type_new.id
-                allowable_field_type_new.sample_type_id = sample_type_id
+                allowable_field_type_new  = AllowableFieldType.new(
+                  field_type_id: field_type_new.id,
+                  sample_type_id: sample_type_id
+                )
                 allowable_field_type_new.save
               end
             end
@@ -155,12 +151,10 @@ class SampleType < ActiveRecord::Base
   # - Any potential errors are handled automatically and silently
   #
   # @param st [Hash] the sample type
-  #
   # @option st[:id] [Int] the id of the sample type
   # @option st[:name] [String] the name of the sample type
   # @option st[:description] [String] the description of the sample type
   # @option st[:field_types] [Hash] the field_type attributes associated with the sample type
-  #
   # feild_types = {
   #   id [Int] the id of the existing field type <or> nil if it is new
   #   name [String] name
@@ -170,12 +164,10 @@ class SampleType < ActiveRecord::Base
   #   choices [String] choices
   #   allowable_field_types [Array] array of allowable field types (for ftype = "sample")
   # }
-  #
   # allowable_field_type = {
   #   id [Int] the id of the existing allowable field type <or> nil if it is new
   #   sample_type_id [Int] id of the allowable field type
   # }
-  #
   # @return the sample type
   def update(st)
     input_name = Input.text(st[:name])
@@ -204,8 +196,8 @@ class SampleType < ActiveRecord::Base
         fid       = Input.number(ft[:id])
         fname     = Input.text(ft[:name])
         ftype     = Input.text(ft[:ftype])
-        frequired = Input.boolean(ft[:required])
-        farray    = Input.boolean(ft[:array])
+        frequired = Input.boolean(ft[:required]) ? 1 : nil
+        farray    = Input.boolean(ft[:array]) ? 1 : nil
         fchoices  = Input.text(ft[:choices])
 
         # Find existing feild_type or create new one

--- a/backend/app/models/sample_type.rb
+++ b/backend/app/models/sample_type.rb
@@ -133,7 +133,8 @@ class SampleType < ActiveRecord::Base
     end
 
     # Remove field_types that are no longer defined
-    # Note: automatically removes allowable field types tied to these field types using mysql foreign key + ondelete cascade
+    # NOTE: also automatically removes allowable field types tied to these field types using mysql foreign key + ondelete cascade
+    # NOTE: Could move this to ield_type.rb but left it here because it is custom to the update
     sql = "delete from field_types where parent_id = #{self.id} and id not in (#{field_type_ids.join(",")})"
     FieldType.connection.execute sql
 

--- a/backend/app/models/sample_type.rb
+++ b/backend/app/models/sample_type.rb
@@ -14,6 +14,10 @@ class SampleType < ActiveRecord::Base
     SampleType.find_by_sql sql
   end
 
+  # Return a specific sample type.
+  #
+  # @param id [Int] the id of the sample type
+  # @return the sample types
   def self.find_id(id)
     sql = "
       select * from sample_types where id = #{id} limit 1
@@ -21,13 +25,13 @@ class SampleType < ActiveRecord::Base
     (SampleType.find_by_sql sql)[0]
   end
 
-  # Return details for a specific sample types.
+  # Return details for a specific sample type.
   #
   # @param id [Int] the id of the sample type
   #
-  # @return the sample types
+  # @return the sample type details
   def self.details(id)
-    # GET FEILD TYPES
+    # Get feild types
     sql = "
       select *, null as 'allowable_field_types'
       from field_types ft
@@ -36,8 +40,8 @@ class SampleType < ActiveRecord::Base
     "
     field_types = FieldType.find_by_sql sql
 
-    # GET SAMPLE_OPTIONS FOR FIELD_TYPE == "SAMPLE"
-    # MAKES <N> CALLS TO THE DB BUT <N> SHOULD NOT BE LARGE
+    # Get sample_options for field_type == "sample"
+    # Makes <n> calls to the db but <n> should not be large
     field_types.each do |ft|
       if ft.ftype == "sample"
         sql = "
@@ -53,11 +57,11 @@ class SampleType < ActiveRecord::Base
       end
     end
 
-    # GET INVENTORY
-    # TODO -- IMPLEMENT THIS WHEN IMPLEMENT INVENTORY
+    # Get inventory
+    # Todo -- implement this when implement inventory
     inventory = 0
 
-    # GET OBJECT TYPES (CONTAINERS)
+    # Get object types (containers)
     sql = "
       select * from object_types where sample_type_id = #{id} order by name
     "
@@ -88,7 +92,7 @@ class SampleType < ActiveRecord::Base
     name = Input.text(st[:name])
     description = Input.text(st[:description])
 
-    # CREATE TEH SAMPLE TYPE
+    # Create teh sample type
     sample_type_new = SampleType.new
     sample_type_new.name = name
     sample_type_new.description = description
@@ -96,10 +100,10 @@ class SampleType < ActiveRecord::Base
     valid = sample_type_new.valid?
     return false, sample_type_new.errors if !valid
 
-    # SAVE THE SAMPLE TYPE IF IT IS VALID
+    # Save the sample type if it is valid
     sample_type_new.save
 
-    # SAVE FIELD TYPE IF THERE IS A FIELD NAME
+    # Save field type if there is a field name
     if st[:field_types].kind_of?(Array)
       st[:field_types].each do |ft|
         fname     = Input.text(ft[:name])

--- a/backend/app/models/sample_type.rb
+++ b/backend/app/models/sample_type.rb
@@ -1,0 +1,233 @@
+# SAMPLE_TYPES TABLE
+class SampleType < ActiveRecord::Base
+
+  validates :name,        presence: true, uniqueness: { case_sensitive: false }
+  validates :description, presence: true
+
+  def self.find_all
+    sql = "
+      select * from sample_types order by name
+    "
+    SampleType.find_by_sql sql
+  end
+
+  def self.find_id(id)
+    sql = "
+      select * from sample_types where id = #{id} limit 1
+    "
+    (SampleType.find_by_sql sql)[0]
+  end
+
+  def self.details(id)
+    # GET FEILD TYPES
+    sql = "
+      select *, null as 'allowable_field_types'
+      from field_types ft
+      where ft.parent_class = 'SampleType' and ft.parent_id = #{id}
+      order by ft.name
+    "
+    field_types = FieldType.find_by_sql sql
+
+    # GET SAMPLE_OPTIONS FOR FIELD_TYPE == "SAMPLE"
+    # MAKES <N> CALLS TO THE DB BUT <N> SHOULD NOT BE LARGE
+    field_types.each do |ft|
+      if ft.ftype == "sample"
+        sql = "
+          select aft.id, aft.field_type_id, aft.sample_type_id, st.name
+          from allowable_field_types aft
+          inner join sample_types st on st.id = aft.sample_type_id
+          where aft.field_type_id = #{ft.id}
+          order by st.name
+        "
+        allowable_field_types = AllowableFieldType.find_by_sql sql
+
+        ft = ft.update( {allowable_field_types: allowable_field_types} )
+      end
+    end
+
+    # GET INVENTORY
+    # TODO -- IMPLEMENT THIS WHEN IMPLEMENT INVENTORY
+    inventory = 0
+
+    # GET OBJECT TYPES (CONTAINERS)
+    sql = "
+      select * from object_types where sample_type_id = #{id} order by name
+    "
+    object_types = ObjectType.find_by_sql sql
+
+    return { field_types: field_types, inventory: inventory, object_types: object_types }
+  end
+
+  def self.create(st)
+    name = Input.text(st[:name])
+    description = Input.text(st[:description])
+
+    # CREATE TEH SAMPLE TYPE
+    sample_type_new = SampleType.new
+    sample_type_new.name = name
+    sample_type_new.description = description
+
+    valid = sample_type_new.valid?
+    return false, sample_type_new.errors if !valid
+
+    # SAVE THE SAMPLE TYPE IF IT IS VALID
+    sample_type_new.save
+
+    # SAVE FIELD TYPE IF THERE IS A FIELD NAME
+    if st[:field_types].kind_of?(Array)
+      st[:field_types].each do |ft|
+        fname     = Input.text(ft[:name])
+        ftype     = Input.text(ft[:ftype])
+        frequired = Input.boolean(ft[:required])
+        farray    = Input.boolean(ft[:array])
+        fchoices  = Input.text(ft[:choices])
+
+        if fname != ""
+          field_type_new  = FieldType.new
+
+          field_type_new.parent_id    = sample_type_new.id
+          field_type_new.name         = fname
+          field_type_new.ftype        = ftype
+          field_type_new.choices      = fchoices
+          field_type_new.array        = farray
+          field_type_new.required     = frequired
+          field_type_new.parent_class = "SampleType"
+          field_type_new.save
+
+          # SAVE ALLOWABLE FIELD TYPES IF THE FIELD TYPE IS "SAMPLE"
+          if ftype == "sample" and ft[:allowable_field_types].kind_of?(Array)
+            ft[:allowable_field_types].each do |aft|
+              sample_type_id = Input.number(aft[:sample_type_id])
+              sql = "select * from sample_types where id = #{sample_type_id} limit 1"
+
+              if (SampleType.find_by_sql sql)[0]
+                allowable_field_type_new  = AllowableFieldType.new
+
+                allowable_field_type_new.field_type_id  = field_type_new.id
+                allowable_field_type_new.sample_type_id = sample_type_id
+                allowable_field_type_new.save
+              end
+            end
+          end
+        end
+      end
+    end
+
+    return sample_type_new, false
+
+  end
+
+  # UPDATE EXISTING SAMPLE TYPE
+  # - UPDATE THE SAMPLE TYPE
+  # - KEEP ANY EXISTING FIELD TYPES (AND CHANGE THEM AS NECESSARY)
+  # - REMOVE ANY FEILD TYPES THAT NO LONGER EXIST
+  # - ADD ANY NEW FEILD TYPES
+  # - ALSO UPDATE ALLOWABLE FIELD TYPES FOR EACH FIELD TYPE
+  # ANY ERRORS ARE HANDLED AUTOMATICALLY AND SILENTLY
+  def update(st)
+    input_name = Input.text(st[:name])
+    input_description = Input.text(st[:description])
+
+    # CHECK FOR DUPLICATES
+
+    # UPDATE NAME AND DESCRIPTION IF NOT BLANK
+    self.name = input_name if input_name
+    self.description = input_description if input_description
+
+    # UPDATE THE SAMPLE TYPE NAME AND DESCRIPTION IF VALID (OTHERWISE LEAVE AS IS)
+    self.save if self.valid?
+
+    # LIST OF FIELD TYPE IDS
+    # - USED TO DELETE FIELD TYPES THAT WERE REMOVED ON UPDATE
+    # - INITIALIZE WITH ID = 0 TO GENERATE THE APPROPRIATE SQL QUERY LATER
+    field_type_ids = [0]
+
+    # SAVE FIELD TYPE IF THERE IS A FIELD NAME
+    if st[:field_types].kind_of?(Array)
+      st[:field_types].each do |ft|
+        # LIST OF ALLOWABLE FIELD TYPE IDS FOR THIS FIELD_TYPE_ID
+        # - USED TO DELETE ALLOWABLE FIELD TYPES THAT WERE REMOVED ON UPDATE
+        # - INITIALIZE WITH ID = 0 TO GENERATE THE APPROPRIATE SQL QUERY LATER
+        allowable_field_type_ids = [0]
+
+        fid       = Input.number(ft[:id])
+        fname     = Input.text(ft[:name])
+        ftype     = Input.text(ft[:ftype])
+        frequired = Input.boolean(ft[:required])
+        farray    = Input.boolean(ft[:array])
+        fchoices  = Input.text(ft[:choices])
+
+        # FIND EXISTING FEILD_TYPE OR CREATE NEW ONE
+        sql = "select * from field_types where id = #{fid} and parent_id = #{self.id} limit 1"
+
+        field_type_update = (FieldType.find_by_sql sql)[0] || FieldType.new
+
+        # SET FNAME IF EXISTS AND INPUT IS NOT BLANK
+        # AWKWARD LOGIC, BUT THAT'S HOW IT WORKS IN V2
+        fname = fname || field_type.name
+
+        if fname != ""
+          field_type_update.parent_id    = self.id
+          field_type_update.name         = fname
+          field_type_update.ftype        = ftype
+          field_type_update.choices      = fchoices
+          field_type_update.array        = farray
+          field_type_update.required     = frequired
+          field_type_update.parent_class = "SampleType"
+          field_type_update.save
+
+          # APPEND TO LIST OF FIELD_TYPE_IDS
+          field_type_id = field_type_update.id
+          field_type_ids << field_type_id
+
+          # SAVE ALLOWABLE FIELD TYPES IF THE FIELD TYPE IS "SAMPLE"
+          if ftype == "sample" and ft[:allowable_field_types].kind_of?(Array)
+            ft[:allowable_field_types].each do |aft|
+              # VERIFY THAT THE SAMPLE_TYPE_ID IS VALID
+              sample_type_id = Input.number(aft[:sample_type_id])
+              sql = "select * from sample_types where id = #{sample_type_id} limit 1"
+
+              if (SampleType.find_by_sql sql)[0]
+                # FIND EXISTING ALLOWABLE_FIELD_TYPE OR CREATE NEW ONE
+                allowable_field_type_id = Input.number(aft[:id])
+                sql = "select * from allowable_field_types where id = #{allowable_field_type_id} and field_type_id = #{field_type_id} limit 1"
+                allowable_field_type_update = (AllowableFieldType.find_by_sql sql)[0] || AllowableFieldType.new
+
+                # CREATE / UPDATE THE ALLOWABLE_FIELD_TYPE
+                allowable_field_type_update.field_type_id  = field_type_id
+                allowable_field_type_update.sample_type_id = sample_type_id
+                allowable_field_type_update.save
+
+                # APPEND TO LIST OF ALLOWABLE_FIELD_TYPE_IDS FOR THIS FIELD_TYPE_ID
+                allowable_field_type_ids << allowable_field_type_update.id
+              end
+            end
+          end
+
+          # REMOVE ALLOWABLE_FIELD_TYPES FOR THIS FIELD TYPE THAT ARE NO LONER DEFINED
+          sql = "delete from allowable_field_types where field_type_id = #{field_type_id} and id not in (#{allowable_field_type_ids.join(",")})"
+          AllowableFieldType.connection.execute sql
+        end
+      end
+    end
+
+    # REMOVE FIELD_TYPES THAT ARE NO LONGER DEFINED
+    # NOTE: AUTOMATICALLY REMOVES ALLOWABLE FIELD TYPES TIED TO THESE FIELD TYPES USING MYSQL FOREIGN KEY + ONDELETE CASCADE
+    sql = "delete from field_types where parent_id = #{self.id} and id not in (#{field_type_ids.join(",")})"
+    FieldType.connection.execute sql
+
+    return self
+  end
+
+  def delete_sample_type
+    # DELETE FIELD_TYPES (THEY DO NOT HAVE FOREIGN KEYS)
+    sql = "delete from field_types where parent_class = 'SampleType' and parent_id = #{self.id}"
+    FieldType.connection.execute sql
+
+    # DELETE SELF
+    self.delete
+
+    return true
+  end
+
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -4,19 +4,15 @@
 class User < ActiveRecord::Base
   has_secure_password
 
-  # Validates the token for the given ip address and permission ID.
-  #
-  # When check_permission_id is 0, checks against all permissions.
-  #
-  # @param ip [String]   the ip address for the access
-  # @param token [String]   the token string
-  # @param check_permission_id [Integer] the ID for the permission (default is 0)
-  # @return [Symbol, Hash] status and response for token validation
-  def self.validate_token(ip:, token:, check_permission_id: 0)
+  # VALIDATE TOKEN (CHECK AGAINST OPTIONAL PERMISSION_ID)
+  # CHECK_PERMISSION_ID DEFAULT TO 0 FOR 'ANY'
+  def self.validate_token(options, check_permission_id = 0)
+    option_token = options[:token].to_s
+    option_ip = options[:ip].to_s
     option_timenow = Time.now.utc
     timeok = (option_timenow - ENV['SESSION_TIMEOUT'].to_i.minutes).to_s[0, 19]
 
-    wheres = sanitize_sql_for_conditions(['ut.token = ? and ut.ip = ?', token, ip])
+    wheres = sanitize_sql_for_conditions(['ut.token = ? and ut.ip = ?', option_token, option_ip])
 
     sql = "
         select ut.*, u.name, u.login, u.permission_ids
@@ -27,37 +23,31 @@ class User < ActiveRecord::Base
       "
     usertoken = (User.find_by_sql sql)[0]
 
-    return [:unauthorized, { error: 'Invalid' }] unless usertoken
-    if usertoken.timenow.to_s[0, 19] < timeok
-      return [:unauthorized, { error: 'Session timeout' }]
+    if !usertoken
+      # INVALID TOKEN OR IP
+      [401, "Invalid."]
+    elsif usertoken.timenow.to_s[0, 19] < timeok
+      # SESSION TIMEOUT
+      # DELETE THE TOKEN
+      deletes = sanitize_sql_for_conditions(['token = ? and ip = ?', option_token, option_ip])
+      sql = "delete from user_tokens where #{deletes} limit 1"
+      User.connection.execute sql
+
+      [401, "Session timeout."]
+    elsif !usertoken.permission?(check_permission_id)
+      # FORBIDDEN
+      [403, nil]
+    else
+      # VALID TOKEN + IP + TIME
+
+      #RESET USER.TIMENOW
+      usertoken.timenow = option_timenow
+      sql = "update user_tokens ut set timenow = '#{option_timenow.to_s[0, 19]}' where #{wheres} limit 1"
+      User.connection.execute sql
+
+      # RETURN USER
+      [200, { id: usertoken.user_id, name: usertoken.name, login: usertoken.login, permission_ids: usertoken.permission_ids }]
     end
-    unless usertoken.permission?(check_permission_id)
-      message = 'Forbidden'
-      permission_name = Permission.permission_ids[check_permission_id]
-      if permission_name
-        message = "#{permission_name.capitalize} permissions required"
-      end
-      return [:forbidden, { error: message }]
-    end
-
-    # VALID TOKEN + IP + TIME
-
-    # RESET USER.TIMENOW
-    usertoken.timenow = option_timenow
-    sql = "update user_tokens ut set timenow = '#{option_timenow.to_s[0, 19]}' where #{wheres} limit 1"
-    User.connection.execute sql
-
-    # RETURN USER
-    [
-      :ok,
-      { user: {
-          id: usertoken.user_id,
-          name: usertoken.name,
-          login: usertoken.login,
-          permission_ids: usertoken.permission_ids
-        }
-      }
-    ]
   end
 
   # SIGN OUT
@@ -86,18 +76,16 @@ class User < ActiveRecord::Base
   # DOES USER HAVE PERMISSIONS FOR <ROLE_ID>
   def permission?(permission_id)
     # RETIRED - ALWAYS FALSE
-    if permission_ids.index(".#{Permission.permission_ids.key('retired')}.")
-      return false
-    end
+    return false if permission_ids.index(".#{Permission.permission_ids.key('retired')}.")
 
     # ANY ROLE - ALWAYS TRUE (EVEN IF ".")
     return true if permission_id.zero?
 
     # CHECK <ROLE_ID> AND CHECK "ADMIN"
-    permission_ids.index(".#{permission_id}.") || permission_ids.index(".#{Permission.permission_ids.key('admin')}.")
+    permission_ids.index(".#{permission_id}.") or permission_ids.index(".#{Permission.permission_ids.key('admin')}.")
   end
 
-  # SET ROLE
+  # SET PERMISSION
   def self.set_permission(user_id, permission_id, val)
     user = User.find_by(id: user_id)
     return false unless user

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ActiveRecord::Base
 
     if !usertoken
       # Invalid token or ip
-      [401, "Invalid."]
+      [401, "Invalid"]
     elsif usertoken.timenow.to_s[0, 19] < timeok
       # Session timeout
       # Delete the token
@@ -40,7 +40,7 @@ class User < ActiveRecord::Base
       sql = "delete from user_tokens where #{deletes} limit 1"
       User.connection.execute sql
 
-      [401, "Session timeout."]
+      [401, "Session timeout"]
     elsif !usertoken.permission?(check_permission_id)
       # Forbidden
       [403, nil]

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base
 
     if !usertoken
       # INVALID TOKEN OR IP
-      [401, "Invalid."]
+      [401, "Invalid"]
     elsif usertoken.timenow.to_s[0, 19] < timeok
       # SESSION TIMEOUT
       # DELETE THE TOKEN

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -11,7 +11,6 @@ class User < ActiveRecord::Base
   #
   # @option options[:token] [String] a token
   # @option options[:ip] [String] an IP address
-  #
   # @return the user
   def self.validate_token(options, check_permission_id = 0)
     option_token = options[:token].to_s
@@ -64,7 +63,6 @@ class User < ActiveRecord::Base
   # @option options[:token] [String] the token
   # @option options[:ip] [String] the IP address associated with the token
   # @option options[:all] [String] optional "true" or "on" to sign the user out of all devices (delete all their tokens)
-  #
   # @return true
   def self.sign_out(options)
     token = options[:token].to_s
@@ -90,7 +88,6 @@ class User < ActiveRecord::Base
   # Check whether user has permission_id
   #
   # @param permission_id [Int] the permission_id to check
-  #
   # @return true
   def permission?(permission_id)
     # Retired - always false
@@ -108,7 +105,6 @@ class User < ActiveRecord::Base
   # @param id [Int] the id of the user
   # @param permission_id [Int] the permission_id to set
   # @param val [Boolean] true to turn permission on, false to turn permission off
-  #
   # @return true
   def self.set_permission(user_id, permission_id, val)
     user = User.find_by(id: user_id)
@@ -134,7 +130,6 @@ class User < ActiveRecord::Base
   #
   # @param conditions [Array] list of specific permission_ids to check (empty array for any permission_id)
   # @param order [String] order by value for the SQL query
-  #
   # @return filtered / sorted list of users
   def self.get_users_by_permission(conditions, order)
     wheres = ''

--- a/backend/app/models/user_token.rb
+++ b/backend/app/models/user_token.rb
@@ -5,7 +5,6 @@ class UserToken < ActiveRecord::Base
   # Create a new token
   #
   # @param this_ip [String] the IP address to associate with the token
-  #
   # @return a new token
   def self.new_token(this_ip)
     exists = true

--- a/backend/app/models/user_token.rb
+++ b/backend/app/models/user_token.rb
@@ -12,9 +12,9 @@ class UserToken < ActiveRecord::Base
 
     # Make 3 attempts to create a token
     while exists && (count < 3)
-      this_token = SecureRandom.hex(64) # 128 characters
-      wheres = sanitize_sql_for_conditions(['ip = ? and token = ?', this_ip, this_token])
-      sql = "select * from user_tokens where #{wheres} limit 1"
+      this_token = SecureRandom.hex(16) # 32 characters
+      conditions = sanitize_sql_for_conditions(['ip = ? and token = ?', this_ip, this_token])
+      sql = "select * from user_tokens where #{conditions} limit 1"
       exists = (UserToken.find_by_sql sql)[0]
 
       count += 1

--- a/backend/app/models/user_token.rb
+++ b/backend/app/models/user_token.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
-# USER_TOKENS TABLE
+# user_tokens table
 class UserToken < ActiveRecord::Base
+  # Create a new token
+  #
+  # @param this_ip [String] the IP address to associate with the token
+  #
+  # @return a new token
   def self.new_token(this_ip)
     exists = true
     count = 0
 
-    # MAKE 3 ATTEMPTS TO CREATE A TOKEN
+    # Make 3 attempts to create a token
     while exists && (count < 3)
       this_token = SecureRandom.hex(64) # 128 characters
       wheres = sanitize_sql_for_conditions(['ip = ? and token = ?', this_ip, this_token])
@@ -16,7 +21,7 @@ class UserToken < ActiveRecord::Base
       count += 1
     end
 
-    # RETURN NIL IF ALL 3 ATTPEMPTS FAIL
+    # Return nil if all 3 attpempts fail
     return nil if exists
 
     this_token

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -17,10 +17,11 @@ production:
 # use the same name as production to avoid issues with switching env in docker
 development:
   <<: *default
+  database: <%= ENV['DB_NAME'] %> #_development
   pool: 5
 
 test:
   <<: *default
-  database: <%= ENV['DB_NAME'] %>
+  database: <%= ENV['DB_NAME'] %>_test
   pool: 5
   timeout: 5000

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,12 +1,53 @@
+# IN GENERAL WE ARE FOLLOWING THE SPIRIT OF RAILS CONVENTIONS WITH THE FOLLOWING CHANGES
+#   - WE ARE STICKING WITH GET AND POST METHODS (SO WE DO NOT HAVE TO PROCESS A HIDDEN "_METHOD" ATTRIBUTE)
+#   - WE ARE USING EXPLICIT URLS BASED ON THE CONTROLLER#ACTION
+#
+# HERE IS A SUMMARY TABLE FOR REFERENCE
+#
+#   Rails Method + Path         API Method + path       Controller#Action  # NOTES
+#   GET        /item            GET   /item             item#index         # retrieve all items
+#   GET        /item/new        ---                     ---                # NOT USED - form is built on the front-end
+#   POST       /item            POST  /item/create      item#create        # create item
+#   GET        /item/:id        GET   /item/:id         item#show          # retrieve item
+#   GET        /item/:id/edit   ---                     ---                # NOT USED - form is built on the front-end
+#   PATCH/PUT  /item/:id        POST  /item/:id/update  item#update        # update item
+#   DELETE     /item/:id        POST  /item/:id/delete  item#delete        # delete item
+#
+# IN ALL CASES WHERE A TOKEN IS PASSED, THE :TOKEN IS PASSED AS A PARAMETER SO IT IS NOT IN THE URL
+
+
 Rails.application.routes.draw do
 
+  # TOKENS
   post 'api/v3/token/create',                    to: 'api/v3/token#create'
   post 'api/v3/token/delete',                    to: 'api/v3/token#delete'
-  post 'api/v3/token/get_user',                  to: 'api/v3/token#get_user'
+  get  'api/v3/token/get_user',                  to: 'api/v3/token#get_user'
 
-  post 'api/v3/users/permissions',                     to: 'api/v3/users#permissions'
-  post 'api/v3/users/set_permission',                  to: 'api/v3/users#set_permission'
+  # PERMISSIONS
+  get  'api/v3/permissions',                     to: 'api/v3/permissions#index'
 
-  post 'api/v3/permissions/get_permissions',                 to: 'api/v3/permissions#get_permissions'
+  # USER PERMISSIONS
+  get  'api/v3/users/permissions',               to: 'api/v3/users#permissions'
+  post 'api/v3/users/permissions/update',        to: 'api/v3/users#permissions_update'
+
+  get 'api/v3/sample_types/create',             to: 'api/v3/sample_types#create'
+  get 'api/v3/sample_types/:id/update',         to: 'api/v3/sample_types#update'
+  get 'api/v3/sample_types/:id/delete',         to: 'api/v3/sample_types#delete'
+
+  # SAMPLE TYPES
+  get  'api/v3/sample_types',                    to: 'api/v3/sample_types#index'
+  post 'api/v3/sample_types/create',             to: 'api/v3/sample_types#create'
+  get  'api/v3/sample_types/:id',                to: 'api/v3/sample_types#show'
+  post 'api/v3/sample_types/:id/update',         to: 'api/v3/sample_types#update'
+  post 'api/v3/sample_types/:id/delete',         to: 'api/v3/sample_types#delete'
+
+  # OBJECT TYPES
+  # get  'api/v3/object_types',                    to: 'api/v3/object_types#index'
+  # post 'api/v3/object_types/create',             to: 'api/v3/object_types#create'
+  # get  'api/v3/object_types/:id',                to: 'api/v3/object_types#show'
+  # post 'api/v3/object_types/:id/update',         to: 'api/v3/object_types#update'
+  # post 'api/v3/object_types/:id/delete',         to: 'api/v3/object_types#delete'
+
 
 end
+

--- a/backend/config/user_agreement.yml
+++ b/backend/config/user_agreement.yml
@@ -1,0 +1,13 @@
+title: End User Agreement
+updated: 21 January 2020
+clauses:
+  - title: No User Agreement
+    text: This instance of Aquarium has no user agreement. If you manage this instance, you may want to add one.
+  - title: Agreement file format
+    text: |
+      A user agreement is given as a YAML file with values for 'title' and 'updated' and a list 'clauses'.
+      The first two values are strings, and the value for updated is the date.
+      Each clause has a 'title' and 'text' both of which are strings.
+      The title of each clause should be preceded by a hyphen ('-').
+  - title: Find out more
+    title: More detail on configuration can be found at the site aquarium.bio.

--- a/backend/db/migrate/20201030000000_permissions.rb
+++ b/backend/db/migrate/20201030000000_permissions.rb
@@ -13,7 +13,7 @@ class Permissions < ActiveRecord::Migration[4.2]
     end
 
     change_column_null :permissions, :name, false
-    add_index :permissions, :name, unique: true
+    add_index :permissions, :name, unique: true     if !index_exists?(:permissions, :name)
 
     # POPULATE ROLES TABLE
     execute <<-SQL

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2020_10_30_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["row1"], name: "index_account_logs_on_row1"
-    t.index ["row2"], name: "index_account_logs_on_row2"
+    t.index ["row2"], name: "fk_rails_8e6656e8a4"
     t.index ["user_id"], name: "index_account_log_associations_on_user_id"
   end
 
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2020_10_30_000000) do
     t.integer "preferred_operation_type_id"
     t.integer "preferred_field_type_id"
     t.index ["parent_class", "parent_id"], name: "index_field_types_on_parent_class_and_parent_id"
+    t.index ["parent_id"], name: "index_field_types_on_sample_type_id"
   end
 
   create_table "field_values", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
@@ -132,6 +133,23 @@ ActiveRecord::Schema.define(version: 2020_10_30_000000) do
     t.index ["child_sample_id"], name: "fk_rails_e04e5b0273"
     t.index ["field_type_id"], name: "index_field_values_on_field_type_id"
     t.index ["parent_class", "parent_id"], name: "index_field_values_on_parent_class_and_parent_id"
+    t.index ["parent_id"], name: "index_field_values_on_sample_id"
+  end
+
+  create_table "folder_contents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.integer "sample_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "folder_id"
+    t.integer "workflow_id"
+  end
+
+  create_table "folders", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.integer "parent_id"
   end
 
   create_table "groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
@@ -170,6 +188,17 @@ ActiveRecord::Schema.define(version: 2020_10_30_000000) do
   end
 
   create_table "job_assignment_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.integer "job_id"
+    t.integer "assigned_by"
+    t.integer "assigned_to"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assigned_by"], name: "index_job_assignment_logs_on_assigned_by"
+    t.index ["assigned_to"], name: "index_job_assignment_logs_on_assigned_to"
+    t.index ["job_id"], name: "index_job_assignment_logs_on_job_id"
+  end
+
+  create_table "job_assignment_logs_old", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "job_id"
     t.integer "assigned_by"
     t.integer "assigned_to"
@@ -240,7 +269,6 @@ ActiveRecord::Schema.define(version: 2020_10_30_000000) do
     t.integer "group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["group_id", "user_id"], name: "group_id_user_id", unique: true
     t.index ["group_id"], name: "index_memberships_on_group_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end
@@ -311,12 +339,12 @@ ActiveRecord::Schema.define(version: 2020_10_30_000000) do
     t.index ["part_id"], name: "index_part_associations_on_part_id"
   end
 
-  create_table "permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
+  create_table "permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.string "name", default: "", null: false
     t.integer "sort"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["name"], name: "index_roles_on_name", unique: true
+    t.index ["name"], name: "index_permissions_on_name", unique: true
   end
 
   create_table "plan_associations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
@@ -396,7 +424,7 @@ ActiveRecord::Schema.define(version: 2020_10_30_000000) do
     t.index ["user_id"], name: "index_user_budget_associations_on_user_id"
   end
 
-  create_table "user_tokens", primary_key: ["ip", "token"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "user_tokens", primary_key: ["ip", "token"], options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "token", limit: 128, null: false
     t.datetime "created_at", null: false
@@ -413,6 +441,7 @@ ActiveRecord::Schema.define(version: 2020_10_30_000000) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.string "remember_token"
+    t.boolean "admin", default: false
     t.string "key"
     t.string "permission_ids", default: "."
     t.index ["login"], name: "index_users_on_login", unique: true

--- a/backend/db/test_seeds.rb
+++ b/backend/db/test_seeds.rb
@@ -1,0 +1,21 @@
+# This file should contain all the record creation needed to seed the database with its default values.
+# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
+#
+# Examples:
+#
+#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
+#   Character.create(name: 'Luke', movie: movies.first)
+Permission.create([
+  {id: 1, name: 'admin',   sort: 1},
+  {id: 2, name: 'manage',  sort: 2},
+  {id: 3, name: 'run',     sort: 3},
+  {id: 4, name: 'design',  sort: 4},
+  {id: 5, name: 'develop', sort: 5},
+  {id: 6, name: 'retired', sort: 6},
+])
+
+User.create([
+  {id: 1, name: 'Factory', login: 'user_1', password_digest: '$2a$04$t1STwkRNJWV35R8Sd6eGKu841QubzwdDY6Rysz55cel2xA4WikwH6', permission_ids: '.1.'},
+  {id: 2, name: 'Factory', login: 'user_2', password_digest: '$2a$04$YFitBLDLIyzxOonLuB4Rd.3yPVj75r/3.uLw1ylq9geavOvsfhY4a', permission_ids: '.2.3.'},
+  {id: 3, name: 'Factory', login: 'user_3', password_digest: '$2a$04$6Y3URfFd8d2ENBD00O7OLe/sAgXw13pNWyP/v9eyqIfOvjh/26/7y', permission_ids: '.1.6.'},
+])

--- a/backend/docs/v3_api.md
+++ b/backend/docs/v3_api.md
@@ -1,0 +1,104 @@
+# API v3 Documentation
+
+This document describes the current API v3
+
+---
+
+## API Status Codes
+
+### Normal Use Case
+
+1. If the API is valid and returns success
+
+    ```bash
+    status: :ok (200) / :created (201)
+    {
+      key_1: value_1,
+      key_2: value_2,
+      ...
+    }
+    ```
+    where each value is always
+    ```bash
+    - an < element >
+    - an { object } if there is always only 1 object for that key
+    - an [ array_of_objects ] if there can be 1-or-more objects for that key
+    ```
+
+0. If the API is valid and returns errors on their input form
+
+    ```bash
+    status: :ok (200)
+    {
+      errors
+    }
+    ```
+    where { errors } is always in the format
+    ```bash
+    {
+      field_1: [ field_1_error_messages ],
+      field_2: [ field_1_error_messages ],
+      ...
+    }
+    ```
+
+### Token & Permission Errors
+
+3. If the API token does not exist
+
+    ```bash
+    status: :unauthorized (401),
+    {
+      error: "Invalid."
+    }
+  ```
+
+0. If the API token is valid but the session has timed out
+
+    ```bash
+    status: :unauthorized (401),
+    {
+      error: "Session timeout."
+    }
+    ```
+
+0. If the API token is valid but the user does not have permission to see the page
+
+    ```bash
+    status: :forbidden (403),
+    {
+      error: "<permission> permissions required." / "Forbidden."
+    }
+    ```
+
+## Implemented API Calls (TODO)
+
+  ### TOKENS
+
+  POST api/v3/token/create
+
+  POST api/v3/token/delete
+
+  GET  api/v3/token/get_user
+
+  ### PERMISSIONS
+
+  get  api/v3/permissions
+
+  ### USER PERMISSIONS
+
+  GET  api/v3/users/permissions
+
+  POST api/v3/users/permissions/update
+
+  ### SAMPLE TYPES
+
+  GET  api/v3/sample_types
+
+  POST api/v3/sample_types/create
+
+  GET  api/v3/sample_types/:id
+
+  POST api/v3/sample_types/:id/update
+
+  POST api/v3/sample_types/:id/delete

--- a/backend/docs/v3_api.md
+++ b/backend/docs/v3_api.md
@@ -62,7 +62,7 @@ This document describes the current API v3
     ```bash
     status: :unauthorized (401),
     {
-      error: "Session timeout."
+      error: "Session timeout"
     }
     ```
 
@@ -71,7 +71,7 @@ This document describes the current API v3
     ```bash
     status: :forbidden (403),
     {
-      error: "<permission> permissions required." / "Forbidden."
+      error: "<permission> permissions required" / "Forbidden"
     }
     ```
 

--- a/backend/docs/v3_api.md
+++ b/backend/docs/v3_api.md
@@ -18,14 +18,16 @@ This document describes the current API v3
       ...
     }
     ```
+
     where each value is always
+
     ```bash
     - an < element >
     - an { object } if there is always only 1 object for that key
     - an [ array_of_objects ] if there can be 1-or-more objects for that key
     ```
 
-0. If the API is valid and returns errors on their input form
+2. If the API is valid and returns errors on their input form
 
     ```bash
     status: :ok (200)
@@ -33,7 +35,9 @@ This document describes the current API v3
       errors
     }
     ```
+
     where { errors } is always in the format
+
     ```bash
     {
       field_1: [ field_1_error_messages ],
@@ -44,16 +48,16 @@ This document describes the current API v3
 
 ### Token & Permission Errors
 
-3. If the API token does not exist
+1. If the API token does not exist
 
-    ```bash
-    status: :unauthorized (401),
-    {
-      error: "Invalid."
-    }
-  ```
+   ```bash
+   status: :unauthorized (401),
+   {
+     error: "Invalid"
+   }
+   ```
 
-0. If the API token is valid but the session has timed out
+2. If the API token is valid but the session has timed out
 
     ```bash
     status: :unauthorized (401),
@@ -62,7 +66,7 @@ This document describes the current API v3
     }
     ```
 
-0. If the API token is valid but the user does not have permission to see the page
+3. If the API token is valid but the user does not have permission to see the page
 
     ```bash
     status: :forbidden (403),
@@ -73,7 +77,7 @@ This document describes the current API v3
 
 ## Implemented API Calls (TODO)
 
-  ### TOKENS
+### TOKENS
 
   POST api/v3/token/create
 
@@ -81,17 +85,17 @@ This document describes the current API v3
 
   GET  api/v3/token/get_user
 
-  ### PERMISSIONS
+### PERMISSIONS
 
   get  api/v3/permissions
 
-  ### USER PERMISSIONS
+### USER PERMISSIONS
 
   GET  api/v3/users/permissions
 
   POST api/v3/users/permissions/update
 
-  ### SAMPLE TYPES
+### SAMPLE TYPES
 
   GET  api/v3/sample_types
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -91,7 +91,7 @@ _start_production_server() {
     exec puma -C config/production_puma.rb -e production
 }
 
-# Starts the production server.
+# Starts the develoment server.
 # First, fixes the local IP address for minio if needed.
 _start_development_server() {
 #     _fix_local_minio_ip

--- a/backend/lib/input.rb
+++ b/backend/lib/input.rb
@@ -3,7 +3,7 @@
 # Process input parameters
 module Input
 
-  # Return text (null if blank)
+  # Return text (nil if blank)
   def self.text(str)
     str = str.to_s.strip
     str = nil if str == ""
@@ -12,7 +12,7 @@ module Input
   end
 
   # Return a number (nil or undefined returns 0)
-  def self.number(n)
+  def self.index(n)
     n = n.to_s.to_i
 
     return n

--- a/backend/lib/input.rb
+++ b/backend/lib/input.rb
@@ -18,12 +18,11 @@ module Input
     return n
   end
 
-  # Return a boolean (1 or nil)
-  def self.boolean(n)
-    n = n.to_s.to_i
-    n == 1 ? 1 : nil
+  # Return a boolean ("true" or "on" returns true)
+  def self.boolean(str)
+    bool = str == "true" || str == "on"
 
-    return n
+    return bool
   end
 
 end

--- a/backend/lib/input.rb
+++ b/backend/lib/input.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# PROCESS INPUT PARAMETERS
+# Process input parameters
 module Input
 
-  # RETURN TEXT (NULL IF BLANK)
+  # Return text (null if blank)
   def self.text(str)
     str = str.to_s.strip
     str = nil if str == ""
@@ -11,14 +11,14 @@ module Input
     return str
   end
 
-  # RETURN A NUMBER (NIL OR UNDEFINED RETURNS 0)
+  # Return a number (nil or undefined returns 0)
   def self.number(n)
     n = n.to_s.to_i
 
     return n
   end
 
-  # RETURN A BOOLEAN (1 OR NIL)
+  # Return a boolean (1 or nil)
   def self.boolean(n)
     n = n.to_s.to_i
     n == 1 ? 1 : nil

--- a/backend/lib/input.rb
+++ b/backend/lib/input.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# PROCESS INPUT PARAMETERS
+module Input
+
+  # RETURN TEXT (NULL IF BLANK)
+  def self.text(str)
+    str = str.to_s.strip
+    str = nil if str == ""
+
+    return str
+  end
+
+  # RETURN A NUMBER (NIL OR UNDEFINED RETURNS 0)
+  def self.number(n)
+    n = n.to_s.to_i
+
+    return n
+  end
+
+  # RETURN A BOOLEAN (1 OR NIL)
+  def self.boolean(n)
+    n = n.to_s.to_i
+    n == 1 ? 1 : nil
+
+    return n
+  end
+
+end

--- a/backend/lib/input.rb
+++ b/backend/lib/input.rb
@@ -11,9 +11,16 @@ module Input
     return str
   end
 
-  # Return a number (nil or undefined returns 0)
-  def self.index(n)
+  # Return an int (nil or undefined returns 0)
+  def self.int(n)
     n = n.to_s.to_i
+
+    return n
+  end
+
+  # Return a float (nil or undefined returns 0)
+  def self.float(n)
+    n = n.to_s.to_f
 
     return n
   end

--- a/backend/setup.sh
+++ b/backend/setup.sh
@@ -52,7 +52,7 @@ fi
 _set_variable 'AQUARIUM_VERSION' '2.8.1'
 _set_variable 'APP_PUBLIC_PORT' '80'
 _set_variable 'S3_PUBLIC_PORT' '9000'
-_set_variable 'DB_NAME' 'production'
+_set_variable 'DB_NAME' 'aquarium'
 _set_variable 'DB_USER' 'aquarium'
 _set_variable 'DB_PASSWORD' 'aSecretAquarium'
 _set_variable 'S3_SERVICE' 'minio'

--- a/backend/spec/api/v3/permissions_controller_spec.rb
+++ b/backend/spec/api/v3/permissions_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V3::PermissionsController, type: :request do
   describe 'api' do
 
-    # SIGN IN USERS
+    # Sign in users
     before :each do
       @token_1 = []
       @token_2 = []
@@ -22,21 +22,21 @@ RSpec.describe Api::V3::PermissionsController, type: :request do
       @token_3 << resp["token"]
     end
 
-    # INVALID GET ROLES
+    # Invalid get roles
     it "invalid_get_permissions" do
-      # BAD TOKEN
+      # Bad token
       get "/api/v3/permissions"
       expect(response).to have_http_status 401
     end
 
-    # FORBIDDEN GET ROLES
+    # Forbidden get roles
     it "forbidden_get_permissions" do
       # RETIRED
       get "/api/v3/permissions?token=#{@token_3[0]}"
       expect(response).to have_http_status 403
     end
 
-    # GET ROLES
+    # Get roles
     it "get_permissions" do
       get "/api/v3/permissions?token=#{@token_1[0]}"
       expect(response).to have_http_status 200

--- a/backend/spec/api/v3/permissions_controller_spec.rb
+++ b/backend/spec/api/v3/permissions_controller_spec.rb
@@ -3,15 +3,10 @@ require 'rails_helper'
 RSpec.describe Api::V3::PermissionsController, type: :request do
   describe 'api' do
 
-    # INITIALIZE AND SIGN IN USERS
-    before :all do
-      @user_1 = create(:user, login: 'user_1', permission_ids:'.1.')
+    # SIGN IN USERS
+    before :each do
       @token_1 = []
-
-      @user_2 = create(:user, login: 'user_2', permission_ids:'.2.3.')
       @token_2 = []
-
-      @user_3 = create(:user, login: 'user_3', permission_ids:'.1.6.')
       @token_3 = []
 
       post "/api/v3/token/create?login=user_1&password=password"
@@ -25,35 +20,28 @@ RSpec.describe Api::V3::PermissionsController, type: :request do
       post "/api/v3/token/create?login=user_3&password=password"
       resp = JSON.parse(response.body)
       @token_3 << resp["token"]
-     end
-
-    # NOTE: DATABASE ENTRIES IN BEFORE :ALL ARE NOT FLUSHED AUTOMATICALLY
-    after :all do
-      @user_1.delete
-      @user_2.delete
-      @user_3.delete
     end
 
     # INVALID GET ROLES
     it "invalid_get_permissions" do
       # BAD TOKEN
-      post "/api/v3/permissions/get_permissions"
+      get "/api/v3/permissions"
       expect(response).to have_http_status 401
     end
 
     # FORBIDDEN GET ROLES
     it "forbidden_get_permissions" do
       # RETIRED
-      post "/api/v3/permissions/get_permissions?token=#{@token_3[0]}"
+      get "/api/v3/permissions?token=#{@token_3[0]}"
       expect(response).to have_http_status 403
     end
 
     # GET ROLES
     it "get_permissions" do
-      post "/api/v3/permissions/get_permissions?token=#{@token_1[0]}"
+      get "/api/v3/permissions?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
 
-      post "/api/v3/permissions/get_permissions?token=#{@token_2[0]}"
+      get "/api/v3/permissions?token=#{@token_2[0]}"
       expect(response).to have_http_status 200
     end
 

--- a/backend/spec/api/v3/sample_types_controller_spec.rb
+++ b/backend/spec/api/v3/sample_types_controller_spec.rb
@@ -1,0 +1,188 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::SampleTypesController, type: :request do
+  describe 'api' do
+
+    # SIGN IN USERS
+    before :all do
+      @token_1 = []
+
+      post "/api/v3/token/create?login=user_1&password=password"
+      resp = JSON.parse(response.body)
+      @token_1 << resp["token"]
+    end
+
+    # CREATE SAMPLE TYPE WITH ERRORS
+    it "invalid_sample_type" do
+      post "/api/v3/sample_types/create?token=#{@token_1[0]}"
+      expect(response).to have_http_status 200
+
+      # NAME CANNOT BE BLANK, DESCRSIPTION CANNOT BE BLANK
+      resp = JSON.parse(response.body)
+      expect(resp["errors"]["name"]).to eq ["can't be blank"]
+      expect(resp["errors"]["description"]).to eq ["can't be blank"]
+    end
+
+
+    # CRUD SAMPLE TYPE
+    # COMPLEX TESTS BUT THEY ARE ALL INTER-WOVEN SO IT IS EASIER THAN BREAKING THEM UP
+    it "crud_sample_type" do
+      # SAMPLE TYPE PARAMETERS TO BE USED AS ALLOWABLE FEILD TYPES
+      params_1 = {
+          id: nil,
+          name: "sample name 1",
+          description: "sample definition",
+          field_types: nil
+      }
+
+      params_2 = {
+          id: nil,
+          name: "sample name 2",
+          description: "sample definition",
+          field_types: nil
+      }
+
+      # CREATE SAMPLE TYPE
+      post "/api/v3/sample_types/create?token=#{@token_1[0]}", :params => params_1
+      expect(response).to have_http_status 201
+
+      resp = JSON.parse(response.body)
+      id_1 = resp["id"]
+
+      # CREATE SAMPLE TYPE
+      post "/api/v3/sample_types/create?token=#{@token_1[0]}", :params => params_2
+      expect(response).to have_http_status 201
+
+      resp = JSON.parse(response.body)
+      id_2 = resp["id"]
+
+      # SAMPLE TYPE PARAMETERS
+      params = {
+          id: nil,
+          name: "sample name 3",
+          description: "sample definition",
+          field_types: [
+              {
+                  id: nil,
+                  name: "field1",
+                  ftype: "sample",
+                  required: false,
+                  array: false,
+                  choices: nil,
+                  allowable_field_types: [
+                      {
+                          id: nil,
+                          sample_type_id: id_1
+                      },
+                      {
+                          id: nil,
+                          sample_type_id: id_2
+                      }
+                  ]
+              },
+              {
+                  id: nil,
+                  name: "field2",
+                  ftype: "string",
+                  required: false,
+                  array: false,
+                  choices: "a, b, c",
+                  allowable_field_types: nil
+              }
+          ]
+      }
+
+      # CREATE SAMPLE TYPE
+      post "/api/v3/sample_types/create?token=#{@token_1[0]}", :params => params
+      expect(response).to have_http_status 201
+
+      resp = JSON.parse(response.body)
+      this_id = resp["id"]
+
+      # GET SAMPLE TYPE
+      get "/api/v3/sample_types/#{this_id}?token=#{@token_1[0]}"
+      expect(response).to have_http_status 200
+
+      # GET THE SAMPLE TYPE IDS
+      resp = JSON.parse(response.body)
+
+      this_ft      = resp["sample_type"]["field_types"]
+      this_ft_id_0 = this_ft[0]["id"]
+      this_ft_id_1 = this_ft[1]["id"]
+      this_aft_0   = this_ft[0]["allowable_field_types"]
+      this_aft_id_0_0 = this_aft_0[0]["id"]
+      this_aft_id_0_1 = this_aft_0[1]["id"]
+
+      # UPDATE SAMPLE TYPE
+      # SWITCH THE VALUES OF THE FIELD TYPES AND THEN CHECK RESULTS
+      # CAN RUN A SLEW OF OTHER TESTS BUT IF IT GETS THESE EVERYTHING SHOULD WORK
+      update_params = {
+          id: this_id,
+          name: "sample name 4",
+          description: "sample definition",
+          field_types: [
+              {
+                  id: this_ft_id_1,
+                  name: "field4",
+                  ftype: "sample",
+                  required: false,
+                  array: false,
+                  choices: nil,
+                  allowable_field_types: [
+                      {
+                          id: this_aft_id_0_0,
+                          sample_type_id: id_1
+                      },
+                      {
+                          id: this_aft_id_0_1,
+                          sample_type_id: id_2
+                      }
+                  ]
+              },
+              {
+                  id: this_ft_id_0,
+                  name: "field3",
+                  ftype: "string",
+                  required: false,
+                  array: false,
+                  choices: "a, b, c",
+                  allowable_field_types: nil
+              }
+          ]
+      }
+
+      post "/api/v3/sample_types/#{this_id}/update?token=#{@token_1[0]}", :params => update_params
+      expect(response).to have_http_status 200
+      resp = JSON.parse(response.body)
+
+      # GET SAMPLE TYPE
+      get "/api/v3/sample_types/#{this_id}?token=#{@token_1[0]}"
+      expect(response).to have_http_status 200
+
+      resp = JSON.parse(response.body)
+
+      # FIELDS SHOULD HAVE SWITCHED
+      update_ft      = resp["sample_type"]["field_types"]
+      update_ft_0    = update_ft[0]["ftype"]
+      update_ft_1    = update_ft[1]["ftype"]
+      update_aft_1   = update_ft[1]["allowable_field_types"]
+      update_aft_1_0 = update_aft_1[0]["sample_type_id"]
+      update_aft_1_1 = update_aft_1[1]["sample_type_id"]
+
+      expect(update_ft_0).to eq "string"
+      expect(update_ft_1).to eq "sample"
+      expect(update_aft_1_0).to eq id_1
+      expect(update_aft_1_1).to eq id_2
+
+      # DELETE SAMPLE TYPES
+      post "/api/v3/sample_types/#{this_id}/delete?token=#{@token_1[0]}"
+      expect(response).to have_http_status 200
+
+      post "/api/v3/sample_types/#{id_1}/delete?token=#{@token_1[0]}"
+      expect(response).to have_http_status 200
+
+      post "/api/v3/sample_types/#{id_2}/delete?token=#{@token_1[0]}"
+      expect(response).to have_http_status 200
+    end
+  end
+end

--- a/backend/spec/api/v3/sample_types_controller_spec.rb
+++ b/backend/spec/api/v3/sample_types_controller_spec.rb
@@ -29,17 +29,21 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
     it "crud_sample_type" do
       # Sample type parameters to be used as allowable feild types
       params_1 = {
+        sample_type: {
           id: nil,
           name: "sample name 1",
           description: "sample definition",
           field_types: nil
+        }
       }
 
       params_2 = {
+        sample_type: {
           id: nil,
           name: "sample name 2",
           description: "sample definition",
           field_types: nil
+        }
       }
 
       # Create sample type
@@ -58,38 +62,40 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
 
       # Sample type parameters
       params = {
+        sample_type: {
           id: nil,
           name: "sample name 3",
           description: "sample definition",
           field_types: [
-              {
+            {
+              id: nil,
+              name: "field1",
+              ftype: "sample",
+              required: false,
+              array: false,
+              choices: nil,
+              allowable_field_types: [
+                {
                   id: nil,
-                  name: "field1",
-                  ftype: "sample",
-                  required: false,
-                  array: false,
-                  choices: nil,
-                  allowable_field_types: [
-                      {
-                          id: nil,
-                          sample_type_id: id_1
-                      },
-                      {
-                          id: nil,
-                          sample_type_id: id_2
-                      }
-                  ]
-              },
-              {
+                  sample_type_id: id_1
+                },
+                {
                   id: nil,
-                  name: "field2",
-                  ftype: "string",
-                  required: false,
-                  array: false,
-                  choices: "a, b, c",
-                  allowable_field_types: nil
-              }
+                  sample_type_id: id_2
+                }
+              ]
+            },
+            {
+              id: nil,
+              name: "field2",
+              ftype: "string",
+              required: false,
+              array: false,
+              choices: "a, b, c",
+              allowable_field_types: nil
+            }
           ]
+        }
       }
 
       # Create sample type
@@ -117,38 +123,40 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
       # Switch the values of the field types and then check results
       # Can run a slew of other tests but if it gets these everything should work
       update_params = {
-          id: this_id,
+        id: this_id,
+        sample_type: {
           name: "sample name 4",
           description: "sample definition",
           field_types: [
-              {
-                  id: this_ft_id_1,
-                  name: "field4",
-                  ftype: "sample",
-                  required: false,
-                  array: false,
-                  choices: nil,
-                  allowable_field_types: [
-                      {
-                          id: this_aft_id_0_0,
-                          sample_type_id: id_1
-                      },
-                      {
-                          id: this_aft_id_0_1,
-                          sample_type_id: id_2
-                      }
-                  ]
-              },
-              {
-                  id: this_ft_id_0,
-                  name: "field3",
-                  ftype: "string",
-                  required: false,
-                  array: false,
-                  choices: "a, b, c",
-                  allowable_field_types: nil
-              }
+            {
+              id: this_ft_id_1,
+              name: "field4",
+              ftype: "sample",
+              required: false,
+              array: false,
+              choices: nil,
+              allowable_field_types: [
+                {
+                  id: this_aft_id_0_0,
+                  sample_type_id: id_1
+                },
+                {
+                  id: this_aft_id_0_1,
+                  sample_type_id: id_2
+                }
+              ]
+            },
+            {
+              id: this_ft_id_0,
+              name: "field3",
+              ftype: "string",
+              required: false,
+              array: false,
+              choices: "a, b, c",
+              allowable_field_types: nil
+            }
           ]
+        }
       }
 
       post "/api/v3/sample_types/#{this_id}/update?token=#{@token_1[0]}", :params => update_params

--- a/backend/spec/api/v3/sample_types_controller_spec.rb
+++ b/backend/spec/api/v3/sample_types_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V3::SampleTypesController, type: :request do
   describe 'api' do
 
-    # SIGN IN USERS
+    # Sign in users
     before :all do
       @token_1 = []
 
@@ -12,7 +12,7 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
       @token_1 << resp["token"]
     end
 
-    # CREATE SAMPLE TYPE WITH ERRORS
+    # Create sample type with errors
     it "invalid_sample_type" do
       post "/api/v3/sample_types/create?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
@@ -24,10 +24,10 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
     end
 
 
-    # CRUD SAMPLE TYPE
-    # COMPLEX TESTS BUT THEY ARE ALL INTER-WOVEN SO IT IS EASIER THAN BREAKING THEM UP
+    # Crud sample type
+    # Complex tests but they are all inter-woven so it is easier than breaking them up
     it "crud_sample_type" do
-      # SAMPLE TYPE PARAMETERS TO BE USED AS ALLOWABLE FEILD TYPES
+      # Sample type parameters to be used as allowable feild types
       params_1 = {
           id: nil,
           name: "sample name 1",
@@ -42,21 +42,21 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
           field_types: nil
       }
 
-      # CREATE SAMPLE TYPE
+      # Create sample type
       post "/api/v3/sample_types/create?token=#{@token_1[0]}", :params => params_1
       expect(response).to have_http_status 201
 
       resp = JSON.parse(response.body)
       id_1 = resp["id"]
 
-      # CREATE SAMPLE TYPE
+      # Create sample type
       post "/api/v3/sample_types/create?token=#{@token_1[0]}", :params => params_2
       expect(response).to have_http_status 201
 
       resp = JSON.parse(response.body)
       id_2 = resp["id"]
 
-      # SAMPLE TYPE PARAMETERS
+      # Sample type parameters
       params = {
           id: nil,
           name: "sample name 3",
@@ -92,18 +92,18 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
           ]
       }
 
-      # CREATE SAMPLE TYPE
+      # Create sample type
       post "/api/v3/sample_types/create?token=#{@token_1[0]}", :params => params
       expect(response).to have_http_status 201
 
       resp = JSON.parse(response.body)
       this_id = resp["id"]
 
-      # GET SAMPLE TYPE
+      # Get sample type
       get "/api/v3/sample_types/#{this_id}?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
 
-      # GET THE SAMPLE TYPE IDS
+      # Get the sample type ids
       resp = JSON.parse(response.body)
 
       this_ft      = resp["sample_type"]["field_types"]
@@ -113,9 +113,9 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
       this_aft_id_0_0 = this_aft_0[0]["id"]
       this_aft_id_0_1 = this_aft_0[1]["id"]
 
-      # UPDATE SAMPLE TYPE
-      # SWITCH THE VALUES OF THE FIELD TYPES AND THEN CHECK RESULTS
-      # CAN RUN A SLEW OF OTHER TESTS BUT IF IT GETS THESE EVERYTHING SHOULD WORK
+      # Update sample type
+      # Switch the values of the field types and then check results
+      # Can run a slew of other tests but if it gets these everything should work
       update_params = {
           id: this_id,
           name: "sample name 4",
@@ -155,13 +155,13 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
       expect(response).to have_http_status 200
       resp = JSON.parse(response.body)
 
-      # GET SAMPLE TYPE
+      # Get sample type
       get "/api/v3/sample_types/#{this_id}?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
 
       resp = JSON.parse(response.body)
 
-      # FIELDS SHOULD HAVE SWITCHED
+      # Fields should have switched
       update_ft      = resp["sample_type"]["field_types"]
       update_ft_0    = update_ft[0]["ftype"]
       update_ft_1    = update_ft[1]["ftype"]
@@ -174,7 +174,7 @@ RSpec.describe Api::V3::SampleTypesController, type: :request do
       expect(update_aft_1_0).to eq id_1
       expect(update_aft_1_1).to eq id_2
 
-      # DELETE SAMPLE TYPES
+      # Delete sample types
       post "/api/v3/sample_types/#{this_id}/delete?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
 

--- a/backend/spec/api/v3/token_controller_spec.rb
+++ b/backend/spec/api/v3/token_controller_spec.rb
@@ -3,15 +3,9 @@ require 'rails_helper'
 RSpec.describe Api::V3::TokenController, type: :request do
   describe 'api' do
 
-    # INITIALIZE USERS
+    # INITIALIZE @TOKEN_1 TO STORE TOKENS
     before :all do
-      @user_1 = create(:user, login: 'user_1')
       @token_1 = []
-    end
-
-    # NOTE: DATABASE ENTRIES IN BEFORE :ALL ARE NOT FLUSHED AUTOMATICALLY
-    after :all do
-      @user_1.delete
     end
 
     # SIGN IN
@@ -49,13 +43,13 @@ RSpec.describe Api::V3::TokenController, type: :request do
 
     # CHECK TOKENS
     it "check_token" do
-      post "/api/v3/token/get_user?token=#{@token_1[0]}"
+      get "/api/v3/token/get_user?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
 
-      post "/api/v3/token/get_user?token=#{@token_1[1]}"
+      get "/api/v3/token/get_user?token=#{@token_1[1]}"
       expect(response).to have_http_status 200
 
-      post "/api/v3/token/get_user?token=#{@token_1[2]}"
+      get "/api/v3/token/get_user?token=#{@token_1[2]}"
       expect(response).to have_http_status 200
     end
 
@@ -65,13 +59,13 @@ RSpec.describe Api::V3::TokenController, type: :request do
       expect(response).to have_http_status 200
 
       # CHECK TOKENS
-      post "/api/v3/token/get_user?token=#{@token_1[0]}"
+      get "/api/v3/token/get_user?token=#{@token_1[0]}"
       expect(response).to have_http_status 401
 
-      post "/api/v3/token/get_user?token=#{@token_1[1]}"
+      get "/api/v3/token/get_user?token=#{@token_1[1]}"
       expect(response).to have_http_status 200
 
-      post "/api/v3/token/get_user?token=#{@token_1[2]}"
+      get "/api/v3/token/get_user?token=#{@token_1[2]}"
       expect(response).to have_http_status 200
     end
 
@@ -87,10 +81,10 @@ RSpec.describe Api::V3::TokenController, type: :request do
       expect(response).to have_http_status 200
 
       # CHECK TOKENS
-      post "/api/v3/token/get_user?token=#{@token_1[1]}"
+      get "/api/v3/token/get_user?token=#{@token_1[1]}"
       expect(response).to have_http_status 401
 
-      post "/api/v3/token/get_user?token=#{@token_1[2]}"
+      get "/api/v3/token/get_user?token=#{@token_1[2]}"
       expect(response).to have_http_status 401
     end
 

--- a/backend/spec/api/v3/token_controller_spec.rb
+++ b/backend/spec/api/v3/token_controller_spec.rb
@@ -3,20 +3,20 @@ require 'rails_helper'
 RSpec.describe Api::V3::TokenController, type: :request do
   describe 'api' do
 
-    # INITIALIZE @TOKEN_1 TO STORE TOKENS
+    # Initialize @token_1 to store tokens
     before :all do
       @token_1 = []
     end
 
-    # SIGN IN
+    # Sign in
     it "invalid_sign_in" do
       post "/api/v3/token/create?login=user_1&password=wrong_password"
       expect(response).to have_http_status 401
     end
 
-    # SIGN IN 3 TIMES
+    # Sign in 3 times
     it "sign_in_3_times" do
-      # SIGN IN AND SET TOKEN
+      # Sign in and set token
       post "/api/v3/token/create?login=user_1&password=password"
       expect(response).to have_http_status 200
 
@@ -24,7 +24,7 @@ RSpec.describe Api::V3::TokenController, type: :request do
       token = resp["token"]
       @token_1 << token
 
-      # SIGN IN AND SET TOKEN
+      # Sign in and set token
       post "/api/v3/token/create?login=user_1&password=password"
       expect(response).to have_http_status 200
 
@@ -32,7 +32,7 @@ RSpec.describe Api::V3::TokenController, type: :request do
       token = resp["token"]
       @token_1 << token
 
-      # SIGN IN AND SET TOKEN
+      # Sign in and set token
       post "/api/v3/token/create?login=user_1&password=password"
       expect(response).to have_http_status 200
 
@@ -41,7 +41,7 @@ RSpec.describe Api::V3::TokenController, type: :request do
       @token_1 << token
     end
 
-    # CHECK TOKENS
+    # Check tokens
     it "check_token" do
       get "/api/v3/token/get_user?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
@@ -53,12 +53,12 @@ RSpec.describe Api::V3::TokenController, type: :request do
       expect(response).to have_http_status 200
     end
 
-    # SIGN OUT
+    # Sign out
     it "sign_out" do
       post "/api/v3/token/delete?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
 
-      # CHECK TOKENS
+      # Check tokens
       get "/api/v3/token/get_user?token=#{@token_1[0]}"
       expect(response).to have_http_status 401
 
@@ -69,18 +69,18 @@ RSpec.describe Api::V3::TokenController, type: :request do
       expect(response).to have_http_status 200
     end
 
-    # INVALID SIGN OUT
+    # Invalid sign out
     it "invalid_sign_out" do
       post "/api/v3/token/delete?token=#{@token_1[0]}"
       expect(response).to have_http_status 401
     end
 
-    # SIGN OUT ALL
+    # Sign out all
     it "sign_out_all" do
       post "/api/v3/token/delete?token=#{@token_1[1]}&all=true"
       expect(response).to have_http_status 200
 
-      # CHECK TOKENS
+      # Check tokens
       get "/api/v3/token/get_user?token=#{@token_1[1]}"
       expect(response).to have_http_status 401
 

--- a/backend/spec/api/v3/users_controller_spec.rb
+++ b/backend/spec/api/v3/users_controller_spec.rb
@@ -3,15 +3,10 @@ require 'rails_helper'
 RSpec.describe Api::V3::UsersController, type: :request do
   describe 'api' do
 
-    # INITIALIZE AND SIGN IN USERS
+    # SIGN IN USERS
     before :all do
-      @user_1 = create(:user, login: 'user_1', permission_ids:'.1.')
       @token_1 = []
-
-      @user_2 = create(:user, login: 'user_2', permission_ids:'.2.3.')
       @token_2 = []
-
-      @user_3 = create(:user, login: 'user_3', permission_ids:'.1.6.')
       @token_3 = []
 
       post "/api/v3/token/create?login=user_1&password=password"
@@ -25,75 +20,68 @@ RSpec.describe Api::V3::UsersController, type: :request do
       post "/api/v3/token/create?login=user_3&password=password"
       resp = JSON.parse(response.body)
       @token_3 << resp["token"]
-     end
-
-    # NOTE: DATABASE ENTRIES IN BEFORE :ALL ARE NOT FLUSHED AUTOMATICALLY
-    after :all do
-      @user_1.delete
-      @user_2.delete
-      @user_3.delete
     end
 
     # INVALID GET USERS AND PERMISSIONS
     it "invalid_get_users_and_permissions" do
       # BAD TOKEN
-      post "/api/v3/users/permissions"
+      get "/api/v3/users/permissions"
       expect(response).to have_http_status 401
     end
 
     # FORBIDDEN GET USERS AND PERMISSIONS
     it "forbidden_get_users_and_permissions" do
       # NOT ADMIN
-      post "/api/v3/users/permissions?token=#{@token_2[0]}"
+      get "/api/v3/users/permissions?token=#{@token_2[0]}"
       expect(response).to have_http_status 403
 
       # ADMIN BUT RETIRED
-      post "/api/v3/users/permissions?token=#{@token_3[0]}"
+      get "/api/v3/users/permissions?token=#{@token_3[0]}"
       expect(response).to have_http_status 403
     end
 
     # GET USERS AND PERMISSIONS
     it "get_users_and_permissions" do
-      post "/api/v3/users/permissions?token=#{@token_1[0]}"
+      get "/api/v3/users/permissions?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
 
-      post "/api/v3/users/permissions?token=#{@token_1[0]}&show=[1,2]"
+      get "/api/v3/users/permissions?token=#{@token_1[0]}&show=[1,2]"
       expect(response).to have_http_status 200
 
-      post "/api/v3/users/permissions?token=#{@token_1[0]}&sort=name"
+      get "/api/v3/users/permissions?token=#{@token_1[0]}&sort=name"
       expect(response).to have_http_status 200
 
-      post "/api/v3/users/permissions?token=#{@token_1[0]}&sort=permission.admin"
+      get "/api/v3/users/permissions?token=#{@token_1[0]}&sort=permission.admin"
       expect(response).to have_http_status 200
     end
 
     # INVALID CHANGE PERMISSION FOR USE
     it "invalid_get_users_and_permissions" do
       # BAD TOKEN
-      post "/api/v3/users/set_permission?user_id=#{@user_2.id}&permission_id=4&value=true"
+      post "/api/v3/users/permissions/update?user_id=2&permission_id=4&value=true"
       expect(response).to have_http_status 401
     end
 
     # FORBIDDEN CHANGE PERMISSION FOR USE
     it "forbidden_get_users_and_permissions" do
       # NOT ADMIN
-      post "/api/v3/users/set_permission?token=#{@token_2[0]}&user_id=#{@user_2.id}&permission_id=4&value=true"
+      post "/api/v3/users/permissions/update?token=#{@token_2[0]}&user_id=2&permission_id=4&value=true"
       expect(response).to have_http_status 403
 
       # ADMIN BUT RETIRED
-      post "/api/v3/users/set_permission?token=#{@token_3[0]}&user_id=#{@user_2.id}&permission_id=4&value=true"
+      post "/api/v3/users/permissions/update?token=#{@token_3[0]}&user_id=2&permission_id=4&value=true"
       expect(response).to have_http_status 403
     end
 
     # CHANGE PERMISSION FOR USER
     it "change_permission" do
-      post "/api/v3/users/set_permission?token=#{@token_1[0]}&user_id=#{@user_2.id}&permission_id=4&value=true"
+      post "/api/v3/users/permissions/update?token=#{@token_1[0]}&user_id=2&permission_id=4&value=true"
       expect(response).to have_http_status 200
 
       resp = JSON.parse(response.body)
       expect(resp["user"]["permission_ids"].index('.4.')).not_to eq(nil)
 
-      post "/api/v3/users/set_permission?token=#{@token_1[0]}&user_id=#{@user_2.id}&permission_id=4"
+      post "/api/v3/users/permissions/update?token=#{@token_1[0]}&user_id=2&permission_id=4"
       expect(response).to have_http_status 200
 
       resp = JSON.parse(response.body)
@@ -102,10 +90,10 @@ RSpec.describe Api::V3::UsersController, type: :request do
 
     # CANNOT CHANGE ADMIN / RETIRED FOR SELF
     it "cannot_change_self_permission_admin_retired" do
-      post "/api/v3/users/set_permission?token=#{@token_1[0]}&user_id=#{@user_1.id}&permission_id=1"
+      post "/api/v3/users/permissions/update?token=#{@token_1[0]}&user_id=1&permission_id=1"
       expect(response).to have_http_status 403
 
-      post "/api/v3/users/set_permission?token=#{@token_1[0]}&user_id=#{@user_1.id}&permission_id=6"
+      post "/api/v3/users/permissions/update?token=#{@token_1[0]}&user_id=1&permission_id=6"
       expect(response).to have_http_status 403
     end
 

--- a/backend/spec/api/v3/users_controller_spec.rb
+++ b/backend/spec/api/v3/users_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V3::UsersController, type: :request do
   describe 'api' do
 
-    # SIGN IN USERS
+    # Sign in users
     before :all do
       @token_1 = []
       @token_2 = []
@@ -22,25 +22,25 @@ RSpec.describe Api::V3::UsersController, type: :request do
       @token_3 << resp["token"]
     end
 
-    # INVALID GET USERS AND PERMISSIONS
+    # Invalid get users and permissions
     it "invalid_get_users_and_permissions" do
-      # BAD TOKEN
+      # Bad token
       get "/api/v3/users/permissions"
       expect(response).to have_http_status 401
     end
 
-    # FORBIDDEN GET USERS AND PERMISSIONS
+    # Forbidden get users and permissions
     it "forbidden_get_users_and_permissions" do
-      # NOT ADMIN
+      # Not admin
       get "/api/v3/users/permissions?token=#{@token_2[0]}"
       expect(response).to have_http_status 403
 
-      # ADMIN BUT RETIRED
+      # Admin but retired
       get "/api/v3/users/permissions?token=#{@token_3[0]}"
       expect(response).to have_http_status 403
     end
 
-    # GET USERS AND PERMISSIONS
+    # Get users and permissions
     it "get_users_and_permissions" do
       get "/api/v3/users/permissions?token=#{@token_1[0]}"
       expect(response).to have_http_status 200
@@ -55,25 +55,25 @@ RSpec.describe Api::V3::UsersController, type: :request do
       expect(response).to have_http_status 200
     end
 
-    # INVALID CHANGE PERMISSION FOR USE
+    # Invalid change permission for use
     it "invalid_get_users_and_permissions" do
-      # BAD TOKEN
+      # Bad token
       post "/api/v3/users/permissions/update?user_id=2&permission_id=4&value=true"
       expect(response).to have_http_status 401
     end
 
-    # FORBIDDEN CHANGE PERMISSION FOR USE
+    # Forbidden change permission for use
     it "forbidden_get_users_and_permissions" do
-      # NOT ADMIN
+      # Not admin
       post "/api/v3/users/permissions/update?token=#{@token_2[0]}&user_id=2&permission_id=4&value=true"
       expect(response).to have_http_status 403
 
-      # ADMIN BUT RETIRED
+      # Admin but retired
       post "/api/v3/users/permissions/update?token=#{@token_3[0]}&user_id=2&permission_id=4&value=true"
       expect(response).to have_http_status 403
     end
 
-    # CHANGE PERMISSION FOR USER
+    # Change permission for user
     it "change_permission" do
       post "/api/v3/users/permissions/update?token=#{@token_1[0]}&user_id=2&permission_id=4&value=true"
       expect(response).to have_http_status 200
@@ -88,7 +88,7 @@ RSpec.describe Api::V3::UsersController, type: :request do
       expect(resp["user"]["permission_ids"].index('.4.')).to eq(nil)
     end
 
-    # CANNOT CHANGE ADMIN / RETIRED FOR SELF
+    # Cannot change admin / retired for self
     it "cannot_change_self_permission_admin_retired" do
       post "/api/v3/users/permissions/update?token=#{@token_1[0]}&user_id=1&permission_id=1"
       expect(response).to have_http_status 403

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -27,12 +27,12 @@ require 'factory_bot_rails'
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
-begin
-  ActiveRecord::Migration.maintain_test_schema!
-rescue ActiveRecord::PendingMigrationError => e
-  puts e.to_s.strip
-  exit 1
-end
+# begin
+#   ActiveRecord::Migration.maintain_test_schema!
+# rescue ActiveRecord::PendingMigrationError => e
+#   puts e.to_s.strip
+#   exit 1
+# end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -94,10 +94,10 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 
-  # SET UP DATABASE CLEANER
-  # - CLEAN THE DB BEFORE STARTING THE SUITE
-  # - CLEAN THE DB AS NEEDED WITH DATABASECLEANER.CLEAN
-  # LOAD TEST_SEEDS.RB FILE
+  # Set up database cleaner
+  # - Clean the db before starting the suite
+  # - Clean the db as needed with DatabaseCleaner.clean
+  # Load test_seeds.rb file
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
     DatabaseCleaner.strategy = :truncation

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -93,4 +93,14 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  # SET UP DATABASE CLEANER
+  # - CLEAN THE DB BEFORE STARTING THE SUITE
+  # - CLEAN THE DB AS NEEDED WITH DATABASECLEANER.CLEAN
+  # LOAD TEST_SEEDS.RB FILE
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :truncation
+    load "#{Rails.root}/db/test_seeds.rb"
+  end
 end

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -59,6 +59,7 @@ _set_variable 'S3_SERVICE' 'minio'
 _set_variable 'S3_ID' 'aquarium_minio'
 _set_variable 'S3_REGION' 'us-west-1'
 _set_variable 'TECH_DASHBOARD' 'false'
+_set_variable 'SESSION_TIMEOUT' '15'
 _set_random 'S3_SECRET_ACCESS_KEY' '40'
 _set_random 'SECRET_KEY_BASE' '64'
 _set_timezone


### PR DESCRIPTION
implemented the api calls for sample_types
- the update method is optimized for db calls

updated api call syntax to match conventions
- get vs. post
- minor syntax changes

used database cleaner for rpsec
- makes tests much more robust because you can directly control database setup and truncation strategy

to run this you will need to set up 2 databases in the SAME docker database container.
- set up the app to run on "production" db (you can do whatever you want with the data there)
- set up rspec to run on "production_test" db (this db is managed automatically by rspec)

If you need help the steps are actually pretty easy. 
1. log into the DB on port 3307 as "root" instead of "aquarium"

2. create the databases you want 
(e.g., "production_test")

3. grant database privileges to the "aquarium" user
(e.g. "GRANT ALL PRIVILEGES ON production_test.* TO 'aquarium'@'%';"

