### PR TITLE
change to preferences api call + support for wizards by first letter

### DIFF
--- a/backend/app/controllers/api/v3/users_controller.rb
+++ b/backend/app/controllers/api/v3/users_controller.rb
@@ -402,16 +402,12 @@ module Api
         render json: { error: 'Invalid' }.to_json, status: :unauthorized and return if !user
 
         # Read inputs
-        preference = params[:preference]
-        value = case preference
-                when "new_samples_private"
-                  Input.boolean(params[:value])
-                when "lab_name"
-                  Input.text_field(params[:value])
-                end
+        new_samples_private = Input.boolean(params[:new_samples_private])
+        lab_name = Input.text_field(params[:lab_name])
 
-        # Update the user lab agreement to true
-        UserProfile.set_user_profile(user.id, params[:preference], value)
+        # Update the preferences
+        UserProfile.set_user_profile(user.id, "new_samples_private", new_samples_private)
+        UserProfile.set_user_profile(user.id, "lab_name", lab_name)
 
         render json: { user: user }.to_json, status: :ok
       end

--- a/backend/app/controllers/api/v3/wizards_controller.rb
+++ b/backend/app/controllers/api/v3/wizards_controller.rb
@@ -64,7 +64,8 @@ module Api
         render json: response.to_json, status: status.to_sym and return if response[:error]
 
         # Get wizards
-        wizards = Wizard.find_all
+        letter = Input.letter(params[:letter])
+        wizards = letter ? Wizard.find_by_first_letter(letter) : Wizard.find_all
 
         render json: { wizards: wizards }.to_json, status: :ok
       end

--- a/backend/app/models/budget.rb
+++ b/backend/app/models/budget.rb
@@ -13,9 +13,9 @@ class Budget < ActiveRecord::Base
     Budget.order(:name)
   end
 
-  # Return all budgets beginning with first letterl ('*' as non-alphanumeric wildcard).
+  # Return all budgets beginning with first letter l ('*' as non-alphanumeric wildcard).
   #
-  # @return all budgets beginning with first letterl ('*' as non-alphanumeric wildcard)
+  # @return all budgets beginning with first letter l ('*' as non-alphanumeric wildcard)
   def self.find_by_first_letter(l)
     if l == "*"
       sql = "select * from budgets where (name regexp '^[^a-zA-Z].*') order by name"

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -10,9 +10,9 @@ class Group < ActiveRecord::Base
     Group.order(:name)
   end
 
-  # Return all groups beginning with first letterl ('*' as non-alphanumeric wildcard).
+  # Return all groups beginning with first letter l ('*' as non-alphanumeric wildcard).
   #
-  # @return all groups beginning with first letterl ('*' as non-alphanumeric wildcard)
+  # @return all groups beginning with first letter l ('*' as non-alphanumeric wildcard)
   def self.find_by_first_letter(l)
     if l == "*"
       sql = "select * from groups where (name regexp '^[^a-zA-Z].*') order by name"

--- a/backend/app/models/parameter.rb
+++ b/backend/app/models/parameter.rb
@@ -58,13 +58,13 @@ class Parameter < ActiveRecord::Base
   # return the parameter
   def update(parameter)
     # Read the parameters
-    input_title = Input.text(parameter[:key])
-    input_message = Input.text(parameter[:value])
-    input_active = Input.text(parameter[:description])
+    input_key = Input.text(parameter[:key])
+    input_value = Input.text(parameter[:value])
+    input_description = Input.text(parameter[:description])
 
-    self.key = input_title
-    self.value = input_message
-    self.description = input_active
+    self.key = input_key
+    self.value = input_value
+    self.description = input_description
 
     valid = self.valid?
     return false, self.errors if !valid

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -16,9 +16,9 @@ class User < ActiveRecord::Base
     User.select("id, name, login, created_at, permission_ids").order(:name)
   end
 
-  # Return all users beginning with first letterl ('*' as non-alphanumeric wildcard).
+  # Return all users beginning with first letter l ('*' as non-alphanumeric wildcard).
   #
-  # @return all users beginning with first letterl ('*' as non-alphanumeric wildcard)
+  # @return all users beginning with first letter l ('*' as non-alphanumeric wildcard)
   def self.find_by_first_letter(l)
     if l == "*"
       sql = "select id, name, login, created_at, permission_ids from users where (name regexp '^[^a-zA-Z].*') order by name"
@@ -257,7 +257,6 @@ class User < ActiveRecord::Base
   # Check whether user has permission_id
   #
   # @param permission_id [Int] the permission_id to check
-  # @param target_id [Int] the user_id of the user being updated
   # @return true
   def permission?(permission_id)
     Permission.ok?(permission_ids, permission_id)

--- a/backend/app/models/wizard.rb
+++ b/backend/app/models/wizard.rb
@@ -1,5 +1,6 @@
 # wizards table
 class Wizard < ActiveRecord::Base
+
   validates :name,        presence: true
   validates :description, presence: true
 
@@ -8,6 +9,18 @@ class Wizard < ActiveRecord::Base
   # @return all wizards
   def self.find_all
     Wizard.order(:name)
+  end
+
+  # Return all wizards beginning with first letter l ('*' as non-alphanumeric wildcard).
+  #
+  # @return all wizards beginning with first letter l ('*' as non-alphanumeric wildcard)
+  def self.find_by_first_letter(l)
+    if l == "*"
+      sql = "select * from wizards where (name regexp '^[^a-zA-Z].*') order by name"
+    else
+      sql = "select * from wizards where name like '#{l}%' order by name"
+    end
+    Wizard.find_by_sql sql
   end
 
   # Return a specific wizard.

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -36,8 +36,8 @@ Rails.application.routes.draw do
   get  'api/v3/users/:id/groups',                  to: 'api/v3/users#groups'
   post 'api/v3/users/:id/update_info',             to: 'api/v3/users#update_info'
   post 'api/v3/users/:id/update_permissions',      to: 'api/v3/users#update_permissions'
-  post 'api/v3/users/:id/agreements/:agreement',   to: 'api/v3/users#agreements', constraints: { agreement: /lab|aquarium/ }
-  post 'api/v3/users/:id/preferences/:preference', to: 'api/v3/users#preferences', constraints: { preference: /new_samples_private|lab_name/ }
+  post 'api/v3/users/:id/agreements/:agreement',   to: 'api/v3/users#agreements', constraints: { agreement: /lab_agreement|aquarium_agreement/ }
+  post 'api/v3/users/:id/preferences',             to: 'api/v3/users#preferences'
 
   # Groups
   get  'api/v3/groups',                                         to: 'api/v3/groups#index'


### PR DESCRIPTION
Ben - some very minor tweaks to the backend to support the object_types branch (front-end for a variety of hamburger menu items). I think this should be straightforward. I wanted to get it into the main v3-refactor branch before we start on the manager pages.  I will also push a new version of the object_types branch with all of these updates already merged.